### PR TITLE
Fix assistant API base URL handling

### DIFF
--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -21,10 +21,15 @@ interface ChatContextType {
 const ChatContext = createContext<ChatContextType | undefined>(undefined);
 
 // 🔑 Get API base from environment
-const API_BASE =
+const RAW_API_BASE =
+  import.meta.env.VITE_API_BASE_URL ||
   import.meta.env.VITE_API_URL ||
   import.meta.env.VITE_API_URL_DOCKER ||
   "http://localhost:5000/api";
+
+const API_BASE = RAW_API_BASE.replace(/\/+$/, "");
+
+const buildUrl = (path: string) => `${API_BASE}/${path.replace(/^\/+/, "")}`;
 
 export const ChatProvider: React.FC<{ children: ReactNode }> = ({
   children,
@@ -46,7 +51,7 @@ export const ChatProvider: React.FC<{ children: ReactNode }> = ({
     if (isOpen) {
       (async () => {
         try {
-          const res = await fetch(`${API_BASE}/api/assistant/history`);
+          const res = await fetch(buildUrl("assistant/history"));
           if (!res.ok) return;
           const history: ChatMessage[] = await res.json();
           if (history.length > 0) {
@@ -79,7 +84,7 @@ export const ChatProvider: React.FC<{ children: ReactNode }> = ({
     addMessage(question, true, productId);
 
     try {
-      const res = await fetch(`${API_BASE}/api/assistant/ask`, {
+      const res = await fetch(buildUrl("assistant/ask"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(
@@ -109,7 +114,7 @@ export const ChatProvider: React.FC<{ children: ReactNode }> = ({
 
   const clearChat = async () => {
     try {
-      await fetch(`${API_BASE}/api/assistant/history`, { method: "DELETE" });
+      await fetch(buildUrl("assistant/history"), { method: "DELETE" });
       setMessages([
         {
           id: "welcome",


### PR DESCRIPTION
## Summary
- normalise the assistant API base URL in `ChatContext`
- update assistant requests to reuse a helper that avoids double `/api` segments

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ceadb8e3d48331ab44f6d26be65a69