### PR TITLE
Align frontend and backend ports to 5000/8000

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,6 @@ jobs:
         run: |
           docker-compose up -d
           sleep 30
-          curl -f http://localhost:3000 || exit 1
-          curl -f http://localhost:8080/api/health || exit 1
+          curl -f http://localhost:5000 || exit 1
+          curl -f http://localhost:8000/api/health || exit 1
           docker-compose down

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -6,5 +6,5 @@ RUN npm install
 
 COPY . .
 
-EXPOSE 3000
+EXPOSE 5000
 CMD ["npm", "run", "dev", "--", "--host"]

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -19,9 +19,9 @@ docker-compose up
 ```
 
 ### 2. Access the Application
-- **Frontend**: http://localhost:3000
-- **Backend API**: http://localhost:8080
-- **Swagger UI**: http://localhost:8080/swagger
+- **Frontend**: http://localhost:5000
+- **Backend API**: http://localhost:8000
+- **Swagger UI**: http://localhost:8000/swagger
 - **Database**: localhost:1433 (sa/YOURPASSWORD)
 
 ## 🏗️ Architecture
@@ -31,7 +31,7 @@ docker-compose up
 ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
 │   Frontend      │    │    Backend      │    │   Database      │
 │   React + Vite  │───▶│   .NET 8 API    │───▶│  SQL Server     │
-│   Port: 3000    │    │   Port: 8080    │    │   Port: 1433    │
+│   Port: 5000    │    │   Port: 8000    │    │   Port: 1433    │
 └─────────────────┘    └─────────────────┘    └─────────────────┘
 ```
 
@@ -129,8 +129,8 @@ docker exec -it aipharm-database /opt/mssql-tools/bin/sqlcmd -S localhost -U sa 
 #### Port Already in Use
 ```bash
 # Check what's using the port
-netstat -ano | findstr :3000
-netstat -ano | findstr :8080
+netstat -ano | findstr :5000
+netstat -ano | findstr :8000
 
 # Kill the process
 taskkill /PID <PID> /F
@@ -162,7 +162,7 @@ docker-compose up frontend
 docker-compose logs backend
 
 # Check database connection
-docker-compose exec backend curl http://localhost:8080/api/health
+docker-compose exec backend curl http://localhost:8000/api/health
 ```
 
 ### Reset Everything
@@ -228,8 +228,8 @@ docker-compose -f docker-compose.prod.yml up -d
 ## 🎉 Success!
 
 If you see:
-- Frontend at http://localhost:3000
-- Backend at http://localhost:8080/swagger
+- Frontend at http://localhost:5000
+- Backend at http://localhost:8000/swagger
 - No errors in logs
 
 You're ready to develop! 🚀

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ docker-compose up
 ```
 
 ### **Access the Application**
-- 🌐 **Frontend**: http://localhost:3000
-- 🔧 **Backend API**: http://localhost:8080
-- 📚 **Swagger Documentation**: http://localhost:8080/swagger
+- 🌐 **Frontend**: http://localhost:5000
+- 🔧 **Backend API**: http://localhost:8000
+- 📚 **Swagger Documentation**: http://localhost:8000/swagger
 - 🗄️ **Database**: localhost:1433 (sa/YOURPASSWORD)
 
 ### **Demo Accounts**
@@ -225,7 +225,7 @@ dotnet test              # Run backend tests
 cp .env.example .env
 
 # Configure your settings
-VITE_API_BASE_URL=http://localhost:8080/api
+VITE_API_BASE_URL=http://localhost:8000/api
 SA_PASSWORD=YourStrongPassword123!
 JWT_KEY=YourSuperSecretJWTKey
 ```
@@ -343,7 +343,7 @@ npm run test:coverage
 ```
 
 ### **API Testing**
-- 📚 **Swagger UI**: http://localhost:8080/swagger
+- 📚 **Swagger UI**: http://localhost:8000/swagger
 - 🔧 **Postman Collection**: Available in `/docs` folder
 - 🤖 **Automated Tests**: Included in CI/CD pipeline
 
@@ -518,7 +518,7 @@ docker-compose up
 <summary>❓ How do I add new products?</summary>
 
 1. Login as admin (admin@aipharm.bg / Admin123!)
-2. Use the Swagger UI at http://localhost:8080/swagger
+2. Use the Swagger UI at http://localhost:8000/swagger
 3. Use the POST /api/products endpoint
 </details>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,20 +20,20 @@ services:
     container_name: aipharm-backend
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
-      - ASPNETCORE_URLS=http://+:8080
+      - ASPNETCORE_URLS=http://+:8000
       - ConnectionStrings__DefaultConnection=Server=database,1433;Database=AIPharm;User Id=sa;Password=Xyzzy2005!;TrustServerCertificate=true;MultipleActiveResultSets=true
       - Jwt__Key=AIPharm-Super-Secret-Key-For-JWT-Tokens-2024-Very-Long-Key-Docker
       - Jwt__Issuer=AIPharm
       - Jwt__Audience=AIPharm-Users
-      - ALLOWED_CORS_ORIGINS=http://localhost:3000
+      - ALLOWED_CORS_ORIGINS=http://localhost:5000
     ports:
-      - "5000:8080"
+      - "8000:8000"
     depends_on:
       - database
     networks:
       - aipharm-network
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/api/health || exit 1"]
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8000/api/health || exit 1"]
     restart: unless-stopped
 
   frontend:
@@ -43,8 +43,9 @@ services:
     container_name: aipharm-frontend
     environment:
       - NODE_ENV=development
-      - VITE_API_BASE_URL=http://aipharm-backend:8080/api
-      - "3000:3000"
+      - VITE_API_BASE_URL=http://aipharm-backend:8000/api
+    ports:
+      - "5000:5000"
     depends_on:
       - backend
     networks:

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,7 +2,7 @@
 
 ## 🔗 Base URL
 ```
-Development: http://localhost:5000/api
+Development: http://localhost:8000/api
 Production: https://your-domain.com/api
 ```
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -158,7 +158,7 @@ az webapp create \
       "image": "yourusername/aipharm-backend:latest",
       "portMappings": [
         {
-          "containerPort": 5000,
+          "containerPort": 8000,
           "protocol": "tcp"
         }
       ],
@@ -271,7 +271,7 @@ server {
 
     # API proxy
     location /api/ {
-        proxy_pass http://localhost:5000/api/;
+        proxy_pass http://localhost:8000/api/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection keep-alive;
@@ -340,7 +340,7 @@ volumes:
 ### Health Checks
 ```bash
 # Check application health
-curl -f http://localhost:5000/api/health
+curl -f http://localhost:8000/api/health
 
 # Docker health check
 docker-compose ps

--- a/exports/Web.md
+++ b/exports/Web.md
@@ -61,9 +61,9 @@ builder.Services.AddCors(options =>
     options.AddPolicy("AllowFrontend", policy =>
         policy.WithOrigins(
                 "http://localhost:5173",
-                "http://localhost:3000",
-                "http://frontend:3000",
-                "http://aipharm-frontend:3000"
+                "http://localhost:5000",
+                "http://frontend:5000",
+                "http://aipharm-frontend:5000"
             )
             .AllowAnyHeader()
             .AllowAnyMethod()

--- a/fix.patch
+++ b/fix.patch
@@ -31,7 +31,7 @@ index 62a53be7ed63b4552c2121e23df5eff2fd00db7f..196b614ea8ddfa12067f01fe0c846e6c
 +  import.meta.env.VITE_API_BASE_URL ||
    import.meta.env.VITE_API_URL ||
    import.meta.env.VITE_API_URL_DOCKER ||
-   "http://localhost:5000/api";
+  "http://localhost:8000/api";
  
 +const API_BASE = RAW_API_BASE.replace(/\/+$/, "");
 +

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -45,7 +45,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 const API_BASE =
   import.meta.env.VITE_API_URL ||
   import.meta.env.VITE_API_URL_DOCKER ||
-  "http://localhost:8080/api";
+  "http://localhost:8000/api";
 
 export const AuthProvider: React.FC<{ children: ReactNode }> = ({
   children,

--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -25,7 +25,7 @@ const RAW_API_BASE =
   import.meta.env.VITE_API_BASE_URL ||
   import.meta.env.VITE_API_URL ||
   import.meta.env.VITE_API_URL_DOCKER ||
-  "http://localhost:8080/api";
+  "http://localhost:8000/api";
 
 const API_BASE = RAW_API_BASE.replace(/\/+$/, "");
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,5 +1,5 @@
 // Normalize base URL (remove trailing slash)
-const RAW_BASE = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8080/api";
+const RAW_BASE = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api";
 const API_BASE = RAW_BASE.replace(/\/+$/, "");
 
 // ---------- Types ----------

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: '0.0.0.0',
-    port: 3000,
+    port: 5000,
     watch: {
       usePolling: true,
     },


### PR DESCRIPTION
## Summary
- expose the backend on port 8000 and the frontend on port 5000 across Docker compose, Dockerfiles, and the CI workflow
- update Vite configuration plus frontend API clients to use the new service ports
- refresh documentation and backend CORS hints so instructions reference the 8000/5000 port mapping

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cebb4b2c5c8331b28efdcd6ecea759