### PR TITLE
Validate product categories and add tests

### DIFF
--- a/AIPharm.Backend/AIPharm.Core.Tests/AIPharm.Core.Tests.csproj
+++ b/AIPharm.Backend/AIPharm.Core.Tests/AIPharm.Core.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AIPharm.Core\AIPharm.Core.csproj" />
+    <ProjectReference Include="..\AIPharm.Domain\AIPharm.Domain.csproj" />
+    <ProjectReference Include="..\AIPharm.Web\AIPharm.Web.csproj" />
+  </ItemGroup>
+</Project>

--- a/AIPharm.Backend/AIPharm.Core.Tests/Controllers/ProductsControllerTests.cs
+++ b/AIPharm.Backend/AIPharm.Core.Tests/Controllers/ProductsControllerTests.cs
@@ -1,0 +1,92 @@
+using AIPharm.Core.DTOs;
+using AIPharm.Core.Interfaces;
+using AIPharm.Web.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace AIPharm.Core.Tests.Controllers;
+
+public class ProductsControllerTests
+{
+    private readonly Mock<IProductService> _productServiceMock;
+    private readonly ProductsController _controller;
+
+    public ProductsControllerTests()
+    {
+        _productServiceMock = new Mock<IProductService>();
+        _controller = new ProductsController(_productServiceMock.Object);
+    }
+
+    [Fact]
+    public async Task CreateProduct_WhenCategoryIsInvalid_ReturnsBadRequest()
+    {
+        var dto = new CreateProductDto { CategoryId = 99 };
+
+        _productServiceMock
+            .Setup(service => service.CreateProductAsync(It.IsAny<CreateProductDto>()))
+            .ThrowsAsync(new ArgumentException("Category not found"));
+
+        var result = await _controller.CreateProduct(dto);
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.Contains("Category", badRequest.Value?.ToString());
+    }
+
+    [Fact]
+    public async Task CreateProduct_WhenSuccessful_ReturnsCreatedAtAction()
+    {
+        var dto = new CreateProductDto { Name = "Painkiller", CategoryId = 1 };
+        var product = new ProductDto { Id = 10, Name = dto.Name, CategoryId = dto.CategoryId };
+
+        _productServiceMock
+            .Setup(service => service.CreateProductAsync(It.IsAny<CreateProductDto>()))
+            .ReturnsAsync(product);
+
+        var result = await _controller.CreateProduct(dto);
+
+        var createdResult = Assert.IsType<CreatedAtActionResult>(result.Result);
+        Assert.Equal(product, createdResult.Value);
+    }
+
+    [Fact]
+    public async Task UpdateProduct_WhenCategoryIsInvalid_ReturnsBadRequest()
+    {
+        var dto = new UpdateProductDto { CategoryId = 5 };
+
+        _productServiceMock
+            .Setup(service => service.UpdateProductAsync(It.IsAny<int>(), It.IsAny<UpdateProductDto>()))
+            .ThrowsAsync(new ArgumentException("Category not found"));
+
+        var result = await _controller.UpdateProduct(1, dto);
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.Contains("Category", badRequest.Value?.ToString());
+    }
+
+    [Fact]
+    public async Task UpdateProduct_WhenProductIsMissing_ReturnsNotFound()
+    {
+        _productServiceMock
+            .Setup(service => service.UpdateProductAsync(It.IsAny<int>(), It.IsAny<UpdateProductDto>()))
+            .ThrowsAsync(new KeyNotFoundException("Product not found"));
+
+        var result = await _controller.UpdateProduct(1, new UpdateProductDto());
+
+        var notFound = Assert.IsType<NotFoundObjectResult>(result.Result);
+        Assert.Contains("Product", notFound.Value?.ToString());
+    }
+
+    [Fact]
+    public async Task DeleteProduct_WhenProductIsMissing_ReturnsNotFound()
+    {
+        _productServiceMock
+            .Setup(service => service.DeleteProductAsync(It.IsAny<int>()))
+            .ThrowsAsync(new KeyNotFoundException("Product not found"));
+
+        var result = await _controller.DeleteProduct(1);
+
+        var notFound = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.Contains("Product", notFound.Value?.ToString());
+    }
+}

--- a/AIPharm.Backend/AIPharm.Core.Tests/Services/ProductServiceTests.cs
+++ b/AIPharm.Backend/AIPharm.Core.Tests/Services/ProductServiceTests.cs
@@ -1,0 +1,173 @@
+using AutoMapper;
+using AIPharm.Core.DTOs;
+using AIPharm.Core.Interfaces;
+using AIPharm.Core.Mapping;
+using AIPharm.Core.Services;
+using AIPharm.Domain.Entities;
+using Moq;
+using Xunit;
+
+namespace AIPharm.Core.Tests.Services;
+
+public class ProductServiceTests
+{
+    private readonly Mock<IRepository<Product>> _productRepositoryMock;
+    private readonly Mock<IRepository<Category>> _categoryRepositoryMock;
+    private readonly IMapper _mapper;
+    private readonly ProductService _productService;
+
+    public ProductServiceTests()
+    {
+        _productRepositoryMock = new Mock<IRepository<Product>>();
+        _categoryRepositoryMock = new Mock<IRepository<Category>>();
+        var mapperConfiguration = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        _mapper = mapperConfiguration.CreateMapper();
+        _productService = new ProductService(
+            _productRepositoryMock.Object,
+            _categoryRepositoryMock.Object,
+            _mapper);
+    }
+
+    [Fact]
+    public async Task CreateProductAsync_WithValidCategory_ReturnsProductDto()
+    {
+        var createDto = new CreateProductDto
+        {
+            Name = "Painkiller",
+            Description = "Fast acting relief",
+            Price = 19.99m,
+            StockQuantity = 10,
+            CategoryId = 1,
+            RequiresPrescription = false
+        };
+
+        var category = new Category { Id = 1, Name = "Analgesics", Icon = "pill" };
+
+        _categoryRepositoryMock
+            .Setup(repo => repo.GetByIdAsync(createDto.CategoryId))
+            .ReturnsAsync(category);
+
+        _productRepositoryMock
+            .Setup(repo => repo.AddAsync(It.IsAny<Product>()))
+            .ReturnsAsync((Product product) =>
+            {
+                product.Id = 42;
+                return product;
+            });
+
+        var result = await _productService.CreateProductAsync(createDto);
+
+        Assert.Equal(42, result.Id);
+        Assert.Equal(createDto.Name, result.Name);
+        Assert.Equal(createDto.CategoryId, result.CategoryId);
+        _categoryRepositoryMock.Verify(repo => repo.GetByIdAsync(createDto.CategoryId), Times.Once);
+        _productRepositoryMock.Verify(repo => repo.AddAsync(It.Is<Product>(p => p.CategoryId == createDto.CategoryId)), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateProductAsync_WithInvalidCategory_ThrowsArgumentException()
+    {
+        var createDto = new CreateProductDto
+        {
+            Name = "Painkiller",
+            Price = 19.99m,
+            StockQuantity = 10,
+            CategoryId = 99
+        };
+
+        _categoryRepositoryMock
+            .Setup(repo => repo.GetByIdAsync(createDto.CategoryId))
+            .ReturnsAsync((Category?)null);
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() => _productService.CreateProductAsync(createDto));
+
+        Assert.Contains($"Category with ID {createDto.CategoryId}", exception.Message);
+        _productRepositoryMock.Verify(repo => repo.AddAsync(It.IsAny<Product>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateProductAsync_WithValidCategory_ReturnsUpdatedProductDto()
+    {
+        var existingProduct = new Product
+        {
+            Id = 5,
+            Name = "Painkiller",
+            CategoryId = 1,
+            Price = 9.99m,
+            StockQuantity = 5,
+            CreatedAt = DateTime.UtcNow.AddDays(-1),
+            UpdatedAt = DateTime.UtcNow.AddDays(-1)
+        };
+
+        var updateDto = new UpdateProductDto
+        {
+            Name = "Painkiller Plus",
+            CategoryId = 2,
+            Price = 14.99m
+        };
+
+        var category = new Category { Id = 2, Name = "Supplements", Icon = "leaf" };
+
+        _productRepositoryMock
+            .Setup(repo => repo.GetByIdAsync(existingProduct.Id))
+            .ReturnsAsync(existingProduct);
+
+        _categoryRepositoryMock
+            .Setup(repo => repo.GetByIdAsync(updateDto.CategoryId!.Value))
+            .ReturnsAsync(category);
+
+        _productRepositoryMock
+            .Setup(repo => repo.UpdateAsync(existingProduct))
+            .ReturnsAsync(existingProduct);
+
+        var result = await _productService.UpdateProductAsync(existingProduct.Id, updateDto);
+
+        Assert.Equal(existingProduct.Id, result.Id);
+        Assert.Equal(updateDto.Name, result.Name);
+        Assert.Equal(updateDto.CategoryId, result.CategoryId);
+        _categoryRepositoryMock.Verify(repo => repo.GetByIdAsync(updateDto.CategoryId.Value), Times.Once);
+        _productRepositoryMock.Verify(repo => repo.UpdateAsync(existingProduct), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateProductAsync_WithInvalidCategory_ThrowsArgumentException()
+    {
+        var existingProduct = new Product
+        {
+            Id = 5,
+            Name = "Painkiller",
+            CategoryId = 1
+        };
+
+        var updateDto = new UpdateProductDto
+        {
+            CategoryId = 99
+        };
+
+        _productRepositoryMock
+            .Setup(repo => repo.GetByIdAsync(existingProduct.Id))
+            .ReturnsAsync(existingProduct);
+
+        _categoryRepositoryMock
+            .Setup(repo => repo.GetByIdAsync(updateDto.CategoryId!.Value))
+            .ReturnsAsync((Category?)null);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => _productService.UpdateProductAsync(existingProduct.Id, updateDto));
+
+        _productRepositoryMock.Verify(repo => repo.UpdateAsync(It.IsAny<Product>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateProductAsync_ProductNotFound_ThrowsKeyNotFoundException()
+    {
+        var updateDto = new UpdateProductDto { Name = "Painkiller" };
+
+        _productRepositoryMock
+            .Setup(repo => repo.GetByIdAsync(It.IsAny<int>()))
+            .ReturnsAsync((Product?)null);
+
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => _productService.UpdateProductAsync(123, updateDto));
+
+        _categoryRepositoryMock.Verify(repo => repo.GetByIdAsync(It.IsAny<int>()), Times.Never);
+    }
+}

--- a/AIPharm.Backend/AIPharm.Core/Services/ProductService.cs
+++ b/AIPharm.Backend/AIPharm.Core/Services/ProductService.cs
@@ -108,6 +108,12 @@ namespace AIPharm.Core.Services
 
         public async Task<ProductDto> CreateProductAsync(CreateProductDto createProductDto)
         {
+            var category = await _categoryRepository.GetByIdAsync(createProductDto.CategoryId);
+            if (category == null)
+            {
+                throw new ArgumentException($"Category with ID {createProductDto.CategoryId} not found");
+            }
+
             var product = _mapper.Map<Product>(createProductDto);
             product.CreatedAt = DateTime.UtcNow;
             product.UpdatedAt = DateTime.UtcNow;
@@ -120,7 +126,16 @@ namespace AIPharm.Core.Services
         {
             var product = await _productRepository.GetByIdAsync(id);
             if (product == null)
-                throw new ArgumentException($"Product with ID {id} not found");
+                throw new KeyNotFoundException($"Product with ID {id} not found");
+
+            if (updateProductDto.CategoryId.HasValue)
+            {
+                var category = await _categoryRepository.GetByIdAsync(updateProductDto.CategoryId.Value);
+                if (category == null)
+                {
+                    throw new ArgumentException($"Category with ID {updateProductDto.CategoryId.Value} not found");
+                }
+            }
 
             _mapper.Map(updateProductDto, product);
             product.UpdatedAt = DateTime.UtcNow;
@@ -133,7 +148,7 @@ namespace AIPharm.Core.Services
         {
             var product = await _productRepository.GetByIdAsync(id);
             if (product == null)
-                throw new ArgumentException($"Product with ID {id} not found");
+                throw new KeyNotFoundException($"Product with ID {id} not found");
 
             product.IsDeleted = true;
             product.UpdatedAt = DateTime.UtcNow;

--- a/AIPharm.Backend/AIPharm.Web/Controllers/ProductsController.cs
+++ b/AIPharm.Backend/AIPharm.Web/Controllers/ProductsController.cs
@@ -74,6 +74,10 @@ namespace AIPharm.Web.Controllers
                 var product = await _productService.CreateProductAsync(createProductDto);
                 return CreatedAtAction(nameof(GetProduct), new { id = product.Id }, product);
             }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
             catch (Exception ex)
             {
                 return StatusCode(500, new { message = "An error occurred while creating the product", error = ex.Message });
@@ -89,6 +93,10 @@ namespace AIPharm.Web.Controllers
                 return Ok(product);
             }
             catch (ArgumentException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (KeyNotFoundException ex)
             {
                 return NotFound(new { message = ex.Message });
             }
@@ -107,6 +115,10 @@ namespace AIPharm.Web.Controllers
                 return NoContent();
             }
             catch (ArgumentException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (KeyNotFoundException ex)
             {
                 return NotFound(new { message = ex.Message });
             }

--- a/AIPharm.Backend/AIPharm.sln
+++ b/AIPharm.Backend/AIPharm.sln
@@ -10,6 +10,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AIPharm.Domain", "AIPharm.D
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AIPharm.Infrastructure", "AIPharm.Infrastructure\AIPharm.Infrastructure.csproj", "{4E7A4AD8-AD6C-4E82-BCFB-F1DD78C256F0}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AIPharm.Core.Tests", "AIPharm.Core.Tests\AIPharm.Core.Tests.csproj", "{BB7A3FA7-DF9B-466C-8964-FEB81DE15B7F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,10 @@ Global
 		{4E7A4AD8-AD6C-4E82-BCFB-F1DD78C256F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4E7A4AD8-AD6C-4E82-BCFB-F1DD78C256F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4E7A4AD8-AD6C-4E82-BCFB-F1DD78C256F0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BB7A3FA7-DF9B-466C-8964-FEB81DE15B7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BB7A3FA7-DF9B-466C-8964-FEB81DE15B7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BB7A3FA7-DF9B-466C-8964-FEB81DE15B7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BB7A3FA7-DF9B-466C-8964-FEB81DE15B7F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- enforce category existence checks in `ProductService` create/update flows and use `KeyNotFoundException` for missing products
- adjust `ProductsController` error handling to surface 400 responses for invalid categories and 404s for missing products
- add an xUnit test project that exercises service and controller behavior for valid and invalid category scenarios

## Testing
- `dotnet test AIPharm.sln` *(fails: `dotnet` CLI not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d06238c8dc8331907ba1c316ef16e6