### PR TITLE
Update home page navigation and product preview

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import Header from './components/Header';
 import HeroSection from './components/HeroSection';
 import CategoryFilter from './components/CategoryFilter';
@@ -10,13 +10,16 @@ import { CartProvider } from './context/CartContext';
 import { ChatProvider } from './context/ChatContext';
 import { AuthProvider } from './context/AuthContext';
 import { LanguageProvider, useLanguage } from './context/LanguageContext';
+import { useChat } from './context/ChatContext';
 import { categories, products, searchProducts, getProductsByCategory } from './data/mockData';
 import { Product } from './types';
 
 function AppContent() {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
+  const [isProductExpanded, setIsProductExpanded] = useState(false);
   const { t } = useLanguage();
+  const { setIsOpen } = useChat();
 
   // Filter products based on search and category
   const filteredProducts = useMemo(() => {
@@ -31,56 +34,137 @@ function AppContent() {
     return result;
   }, [searchTerm, selectedCategory]);
 
+  const isDefaultView = !searchTerm.trim() && !selectedCategory;
+
+  const displayedProducts = useMemo(() => {
+    if (isDefaultView && !isProductExpanded) {
+      return filteredProducts.slice(0, 4);
+    }
+    return filteredProducts;
+  }, [filteredProducts, isDefaultView, isProductExpanded]);
+
   // Show hero only when no search or category is selected
-  const showHero = !searchTerm.trim() && !selectedCategory;
+  const showHero = isDefaultView;
 
   const handleSearch = (term: string) => {
     setSearchTerm(term);
     if (term.trim() === '') {
       setSelectedCategory(null);
+      setIsProductExpanded(false);
+    } else {
+      setSelectedCategory(null);
+      setIsProductExpanded(true);
     }
   };
 
   const handleCategoryChange = (categoryId: number | null) => {
     setSelectedCategory(categoryId);
     setSearchTerm('');
+    setIsProductExpanded(categoryId !== null);
   };
+
+  const scrollToSection = useCallback((sectionId: string) => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    const target = document.getElementById(sectionId);
+    if (target) {
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, []);
+
+  const handleViewProducts = useCallback(() => {
+    setIsProductExpanded(true);
+    scrollToSection('products');
+  }, [scrollToSection]);
+
+  const handleOpenAssistant = useCallback(() => {
+    setIsOpen(true);
+  }, [setIsOpen]);
+
+  const handleNavigateToCategories = useCallback(() => {
+    scrollToSection('categories');
+  }, [scrollToSection]);
+
+  const handleNavigateToProducts = useCallback(() => {
+    setIsProductExpanded(true);
+    scrollToSection('products');
+  }, [scrollToSection]);
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header onSearch={handleSearch} searchTerm={searchTerm} />
+      <Header
+        onSearch={handleSearch}
+        searchTerm={searchTerm}
+        onNavigateToCategories={handleNavigateToCategories}
+        onNavigateToProducts={handleNavigateToProducts}
+      />
 
-      {showHero && <HeroSection />}
+      {showHero && (
+        <HeroSection
+          onViewProducts={handleViewProducts}
+          onOpenAssistant={handleOpenAssistant}
+        />
+      )}
 
       <main className="container mx-auto px-4 py-8 bg-white min-h-screen">
-        <CategoryFilter
-          selectedCategory={selectedCategory}
-          onCategoryChange={handleCategoryChange}
-          categories={categories}
-        />
+        <section id="categories" className="scroll-mt-28">
+          <CategoryFilter
+            selectedCategory={selectedCategory}
+            onCategoryChange={handleCategoryChange}
+            categories={categories}
+          />
+        </section>
 
-        {/* Results header */}
-        {(searchTerm || selectedCategory) && (
-          <div className="mb-8 bg-white rounded-2xl shadow-sm border border-gray-100 p-6">
-            <h2 className="text-2xl font-bold text-gray-900 mb-2">
-              {searchTerm
-                ? `${t('products.resultsFor')} "${searchTerm}"`
-                : selectedCategory
-                ? `${t('products.category')}: ${
-                    categories.find((c) => c.id === selectedCategory)?.name ||
-                    t('products.unknown')
-                  }`
-                : t('products.allProducts')}
-            </h2>
-            <p className="text-gray-600 flex items-center">
-              <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-emerald-100 text-emerald-800">
-                {filteredProducts.length} {t('products.products')}
-              </span>
-            </p>
+        <section id="products" className="scroll-mt-28">
+          <div className="mb-8 rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h2 className="text-2xl font-bold text-gray-900">
+                  {isDefaultView && !isProductExpanded
+                    ? t('products.featuredTitle')
+                    : searchTerm
+                    ? `${t('products.resultsFor')} "${searchTerm}"`
+                    : selectedCategory
+                    ? `${t('products.category')}: ${
+                        categories.find((c) => c.id === selectedCategory)?.name ||
+                        t('products.unknown')
+                      }`
+                    : t('products.allProducts')}
+                </h2>
+                <p className="mt-1 text-gray-600">
+                  {isDefaultView && !isProductExpanded
+                    ? t('products.featuredSubtitle')
+                    : `${filteredProducts.length} ${t('products.products')}`}
+                </p>
+              </div>
+
+              <div className="flex items-center gap-3">
+                {!isDefaultView || isProductExpanded ? (
+                  <span className="inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-sm font-medium text-emerald-700">
+                    {filteredProducts.length} {t('products.products')}
+                  </span>
+                ) : (
+                  <span className="text-sm text-gray-500">
+                    {displayedProducts.length}/{products.length} {t('products.products')}
+                  </span>
+                )}
+
+                {isDefaultView && products.length > displayedProducts.length && (
+                  <button
+                    type="button"
+                    onClick={() => setIsProductExpanded((prev) => !prev)}
+                    className="inline-flex items-center rounded-full border border-emerald-500 px-4 py-2 text-sm font-semibold text-emerald-600 transition-colors duration-200 hover:bg-emerald-50"
+                  >
+                    {isProductExpanded ? t('products.showLess') : t('products.viewAll')}
+                  </button>
+                )}
+              </div>
+            </div>
           </div>
-        )}
 
-        <ProductGrid products={filteredProducts} isLoading={false} />
+          <ProductGrid products={displayedProducts} isLoading={false} />
+        </section>
       </main>
 
       <Footer />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,9 +12,16 @@ import AdminPanel from './admin/AdminPanel';
 interface HeaderProps {
   onSearch: (term: string) => void;
   searchTerm: string;
+  onNavigateToCategories: () => void;
+  onNavigateToProducts: () => void;
 }
 
-const Header: React.FC<HeaderProps> = ({ onSearch, searchTerm }) => {
+const Header: React.FC<HeaderProps> = ({
+  onSearch,
+  searchTerm,
+  onNavigateToCategories,
+  onNavigateToProducts,
+}) => {
   const { state, dispatch } = useCart();
   const { user, isAuthenticated, isAdmin, logout } = useAuth();
   const { t } = useLanguage();
@@ -39,6 +46,24 @@ const Header: React.FC<HeaderProps> = ({ onSearch, searchTerm }) => {
   const openAdminPanel = () => {
     setShowUserMenu(false);
     setShowAdminPanel(true);
+  };
+
+  const navigationItems = [
+    {
+      key: 'categories',
+      label: t('navigation.categories'),
+      onClick: onNavigateToCategories,
+    },
+    {
+      key: 'products',
+      label: t('navigation.products'),
+      onClick: onNavigateToProducts,
+    },
+  ];
+
+  const handleNavigationClick = (callback: () => void) => {
+    callback();
+    setIsMenuOpen(false);
   };
 
   return (
@@ -183,6 +208,20 @@ const Header: React.FC<HeaderProps> = ({ onSearch, searchTerm }) => {
           </div>
         </div>
 
+        {/* Desktop navigation */}
+        <nav className="hidden md:flex items-center space-x-2 border-t border-gray-100 py-3 text-sm font-medium text-gray-600">
+          {navigationItems.map((item) => (
+            <button
+              key={item.key}
+              type="button"
+              onClick={() => handleNavigationClick(item.onClick)}
+              className="relative rounded-full px-4 py-2 transition-colors duration-200 hover:bg-emerald-50 hover:text-emerald-700"
+            >
+              {item.label}
+            </button>
+          ))}
+        </nav>
+
         {/* Mobile search */}
         <div className="md:hidden pb-4">
           <div className="relative">
@@ -201,9 +240,18 @@ const Header: React.FC<HeaderProps> = ({ onSearch, searchTerm }) => {
       {/* Mobile menu */}
       {isMenuOpen && (
         <div className="md:hidden bg-white border-t border-gray-100 py-4 px-4 space-y-3">
-          <button className="block w-full text-left py-2 text-gray-700 hover:text-emerald-600 transition-colors">
-            {t('categories.title')}
-          </button>
+          <div className="space-y-2 pb-3 border-b border-gray-100">
+            {navigationItems.map((item) => (
+              <button
+                key={item.key}
+                type="button"
+                onClick={() => handleNavigationClick(item.onClick)}
+                className="block w-full rounded-lg px-3 py-2 text-left text-gray-700 transition-colors duration-200 hover:bg-emerald-50 hover:text-emerald-700"
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
           <button className="block w-full text-left py-2 text-gray-700 hover:text-emerald-600 transition-colors">
             {t('footer.promotions')}
           </button>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -2,7 +2,12 @@ import React from "react";
 import { ArrowRight, Sparkles } from "lucide-react";
 import { useLanguage } from "../context/LanguageContext";
 
-const HeroSection: React.FC = () => {
+interface HeroSectionProps {
+  onViewProducts: () => void;
+  onOpenAssistant: () => void;
+}
+
+const HeroSection: React.FC<HeroSectionProps> = ({ onViewProducts, onOpenAssistant }) => {
   const { t } = useLanguage();
 
   return (
@@ -35,11 +40,19 @@ const HeroSection: React.FC = () => {
 
             {/* CTA Buttons */}
             <div className="flex flex-col sm:flex-row gap-3 mb-8 justify-center">
-              <button className="group bg-emerald-600 hover:bg-emerald-700 text-white font-semibold py-3 px-6 rounded-full transition-all duration-300 transform hover:scale-105 shadow-lg hover:shadow-xl flex items-center justify-center">
+              <button
+                type="button"
+                onClick={onViewProducts}
+                className="group bg-emerald-600 hover:bg-emerald-700 text-white font-semibold py-3 px-6 rounded-full transition-all duration-300 transform hover:scale-105 shadow-lg hover:shadow-xl flex items-center justify-center"
+              >
                 <span>{t("hero.viewProducts")}</span>
                 <ArrowRight className="w-5 h-5 ml-2 group-hover:translate-x-1 transition-transform duration-300" />
               </button>
-              <button className="group border-2 border-emerald-600 text-emerald-600 hover:bg-emerald-600 hover:text-white font-semibold py-3 px-6 rounded-full transition-all duration-300 transform hover:scale-105">
+              <button
+                type="button"
+                onClick={onOpenAssistant}
+                className="group border-2 border-emerald-600 text-emerald-600 hover:bg-emerald-600 hover:text-white font-semibold py-3 px-6 rounded-full transition-all duration-300 transform hover:scale-105"
+              >
                 {t("hero.aiAssistant")}
               </button>
             </div>

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,13 +1,31 @@
 import React from 'react';
+import { useLanguage } from '../context/LanguageContext';
 
-const AIPharmLogo: React.FC<{ className?: string }> = ({ className = "h-8" }) => {
+interface LogoProps {
+  className?: string;
+}
+
+const AIPharmLogo: React.FC<LogoProps> = ({ className = 'h-10' }) => {
+  const { t } = useLanguage();
+
   return (
-    <img 
-      src="/aipharm-logo.png" 
-      alt="AIPHARM+" 
-      className={`${className} object-contain`}
-      style={{ maxHeight: '60px', height: 'auto' }}
-    />
+    <div className="flex items-center space-x-3">
+      <div
+        className={`flex aspect-square items-center justify-center rounded-2xl bg-emerald-50 p-2 shadow-inner ${className}`}
+      >
+        <img
+          src="/pharmacy-icon.svg"
+          alt={t('header.title')}
+          className="h-full w-full object-contain text-emerald-600"
+        />
+      </div>
+      <div className="leading-tight">
+        <p className="text-xl font-bold text-emerald-700">{t('header.title')}</p>
+        <p className="text-xs uppercase tracking-[0.25em] text-emerald-500">
+          {t('header.subtitle')}
+        </p>
+      </div>
+    </div>
   );
 };
 

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -12,6 +12,7 @@ const translations = {
   bg: {
     // Header
     'header.title': 'AIPHARM+',
+    'header.subtitle': 'AI аптека и асистент',
     'header.search': 'Търсете лекарства, витамини, козметика...',
     'header.phone': '+359 2 123 4567',
     'header.freeDelivery': 'Безплатна доставка над €25',
@@ -24,6 +25,10 @@ const translations = {
     'header.adminPanel': 'Админ панел',
     'header.hello': 'Здравейте',
     'header.administrator': 'Администратор',
+
+    // Navigation
+    'navigation.categories': 'Категории',
+    'navigation.products': 'Продукти',
 
     // Hero Section
     'hero.title': 'AIPHARM+',
@@ -49,6 +54,8 @@ const translations = {
     'categories.children': 'Детски продукти',
 
     // Products
+    'products.featuredTitle': 'Акцентирани продукти',
+    'products.featuredSubtitle': 'Показваме селекция от най-търсените ни предложения.',
     'products.resultsFor': 'Резултати за',
     'products.category': 'Категория',
     'products.unknown': 'Неизвестна',
@@ -57,6 +64,7 @@ const translations = {
     'products.noProducts': 'Няма намерени продукти',
     'products.tryDifferent': 'Опитайте с различни ключови думи или разгледайте нашите категории',
     'products.viewAll': 'Разгледайте всички продукти',
+    'products.showLess': 'Покажи по-малко',
     'products.prescription': 'Рецепта',
     'products.activeIngredient': 'Активна съставка',
     'products.dosage': 'Дозировка',
@@ -319,6 +327,7 @@ const translations = {
   en: {
     // Header
     'header.title': 'AIPHARM+',
+    'header.subtitle': 'AI pharmacy & assistant',
     'header.search': 'Search medicines, vitamins, cosmetics...',
     'header.phone': '+359 2 123 4567',
     'header.freeDelivery': 'Free delivery over €25',
@@ -331,6 +340,10 @@ const translations = {
     'header.adminPanel': 'Admin Panel',
     'header.hello': 'Hello',
     'header.administrator': 'Administrator',
+
+    // Navigation
+    'navigation.categories': 'Categories',
+    'navigation.products': 'Products',
 
     // Hero Section
     'hero.title': 'AIPHARM+',
@@ -356,6 +369,8 @@ const translations = {
     'categories.children': 'Children Products',
 
     // Products
+    'products.featuredTitle': 'Featured products',
+    'products.featuredSubtitle': 'A quick look at some of our most popular picks.',
     'products.resultsFor': 'Results for',
     'products.category': 'Category',
     'products.unknown': 'Unknown',
@@ -364,6 +379,7 @@ const translations = {
     'products.noProducts': 'No products found',
     'products.tryDifferent': 'Try different keywords or browse our categories',
     'products.viewAll': 'View all products',
+    'products.showLess': 'Show less',
     'products.prescription': 'Prescription',
     'products.activeIngredient': 'Active Ingredient',
     'products.dosage': 'Dosage',


### PR DESCRIPTION
## Summary
- add scroll-aware navigation hooks so the hero CTAs open the catalog preview or AI assistant and show only a small product selection by default
- introduce a dedicated categories/products menu in the header for desktop and mobile navigation
- refresh the logo component and translations to display the pharmacy icon with supporting text and new navigation labels

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d06f63e2308331880848e9dd4c6741