### PR TITLE
Fix homepage navigation and assistant button after merge issues

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,15 +39,35 @@ function AppContent() {
 
   const isDefaultView = !searchTerm.trim() && !selectedCategory;
 
-  const displayedProducts = useMemo(() => {
-    if (isDefaultView && !isProductExpanded) {
-      return filteredProducts.slice(0, 4);
-    }
-    return filteredProducts;
-  }, [filteredProducts, isDefaultView, isProductExpanded]);
-
   // Show hero only when no search or category is selected
   const showHero = isDefaultView;
+
+  const handleNavigateToCategories = () => {
+    setSearchTerm('');
+    setSelectedCategory(null);
+
+    if (location.pathname !== '/') {
+      navigate('/');
+    }
+
+    if (typeof window !== 'undefined') {
+      const categoriesSection = document.getElementById('category-filter');
+      if (categoriesSection) {
+        categoriesSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      } else {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      }
+    }
+  };
+
+  const handleNavigateToProducts = () => {
+    setSelectedCategory(null);
+    setSearchTerm('');
+
+    if (location.pathname !== '/products') {
+      navigate('/products');
+    }
+  };
 
   const handleSearch = (term: string) => {
     setSearchTerm(term);
@@ -71,7 +91,12 @@ function AppContent() {
 
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
-      <Header onSearch={handleSearch} searchTerm={searchTerm} />
+      <Header
+        onSearch={handleSearch}
+        searchTerm={searchTerm}
+        onNavigateToCategories={handleNavigateToCategories}
+        onNavigateToProducts={handleNavigateToProducts}
+      />
       <div className="flex-1">
         <Routes>
           <Route

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -2,14 +2,15 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { ArrowRight, Sparkles } from "lucide-react";
 import { useLanguage } from "../context/LanguageContext";
+import { useChat } from "../context/ChatContext";
 
-interface HeroSectionProps {
-  onViewProducts: () => void;
-  onOpenAssistant: () => void;
-}
-
-const HeroSection: React.FC<HeroSectionProps> = ({ onViewProducts, onOpenAssistant }) => {
+const HeroSection: React.FC = () => {
   const { t } = useLanguage();
+  const { setIsOpen } = useChat();
+
+  const handleOpenAssistant = () => {
+    setIsOpen(true);
+  };
 
   return (
     <div className="relative bg-gradient-to-br from-emerald-50 via-white to-teal-50 overflow-hidden">
@@ -48,7 +49,10 @@ const HeroSection: React.FC<HeroSectionProps> = ({ onViewProducts, onOpenAssista
                 <span>{t("hero.viewProducts")}</span>
                 <ArrowRight className="w-5 h-5 ml-2 group-hover:translate-x-1 transition-transform duration-300" />
               </Link>
-              <button className="group border-2 border-emerald-600 text-emerald-600 hover:bg-emerald-600 hover:text-white font-semibold py-3 px-6 rounded-full transition-all duration-300 transform hover:scale-105">
+              <button
+                onClick={handleOpenAssistant}
+                className="group border-2 border-emerald-600 text-emerald-600 hover:bg-emerald-600 hover:text-white font-semibold py-3 px-6 rounded-full transition-all duration-300 transform hover:scale-105"
+              >
                 {t("hero.aiAssistant")}
               </button>
             </div>

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -38,11 +38,13 @@ const HomePage: React.FC<HomePageProps> = ({
       {showHero && <HeroSection />}
 
       <main className="container mx-auto px-4 py-8 bg-white min-h-screen">
-        <CategoryFilter
-          selectedCategory={selectedCategory}
-          onCategoryChange={onCategoryChange}
-          categories={categories}
-        />
+        <section id="category-filter">
+          <CategoryFilter
+            selectedCategory={selectedCategory}
+            onCategoryChange={onCategoryChange}
+            categories={categories}
+          />
+        </section>
 
         {(searchTerm || selectedCategory) && (
           <div className="mb-8 bg-white rounded-2xl shadow-sm border border-gray-100 p-6">


### PR DESCRIPTION
## Summary
- restore the homepage navigation handlers and pass them through the header
- rework the hero section to use the chat context so the AI assistant button opens the chat again
- add a category section anchor so header navigation scrolls correctly on the home page

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d07464b6fc8331b4299389adbe2b0a