### PR TITLE
Add categories landing page and update navigation behavior

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Routes, Route, Navigate, useNavigate, useLocation } from 'react-router-dom';
 import Header from './components/Header';
 import Footer from './components/Footer';
@@ -12,6 +12,7 @@ import { categories, products, searchProducts, getProductsByCategory } from './d
 import { Product } from './types';
 import HomePage from './components/pages/HomePage';
 import ProductsPage from './components/pages/ProductsPage';
+import CategoriesPage from './components/pages/CategoriesPage';
 import Services from './components/pages/Services';
 import AboutUs from './components/pages/AboutUs';
 import Contacts from './components/pages/Contacts';
@@ -23,6 +24,17 @@ function AppContent() {
   const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
   const navigate = useNavigate();
   const location = useLocation();
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+
+    if (location.pathname === '/categories') {
+      setSearchTerm('');
+      setSelectedCategory(null);
+    }
+  }, [location.pathname]);
 
   // Filter products based on search and category
   const filteredProducts = useMemo(() => {
@@ -46,17 +58,8 @@ function AppContent() {
     setSearchTerm('');
     setSelectedCategory(null);
 
-    if (location.pathname !== '/') {
-      navigate('/');
-    }
-
-    if (typeof window !== 'undefined') {
-      const categoriesSection = document.getElementById('category-filter');
-      if (categoriesSection) {
-        categoriesSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      } else {
-        window.scrollTo({ top: 0, behavior: 'smooth' });
-      }
+    if (location.pathname !== '/categories') {
+      navigate('/categories');
     }
   };
 
@@ -109,6 +112,17 @@ function AppContent() {
                 filteredProducts={filteredProducts}
                 categories={categories}
                 showHero={showHero}
+                allProducts={products}
+              />
+            )}
+          />
+          <Route
+            path="/categories"
+            element={(
+              <CategoriesPage
+                categories={categories}
+                products={products}
+                onCategorySelect={handleCategoryChange}
               />
             )}
           />

--- a/src/components/CategoryFilter.tsx
+++ b/src/components/CategoryFilter.tsx
@@ -1,15 +1,9 @@
 import React from "react";
+import { Heart, Grid3X3 } from "lucide-react";
+
 import { Category } from "../types";
-import {
-  Pill,
-  Heart,
-  Thermometer,
-  Car,
-  Droplet,
-  Baby,
-  Grid3X3,
-} from "lucide-react";
 import { useLanguage } from "../context/LanguageContext";
+import { getCategoryDisplayName, getCategoryIcon } from "../utils/categories";
 
 interface CategoryFilterProps {
   selectedCategory: number | null;
@@ -17,36 +11,12 @@ interface CategoryFilterProps {
   categories: Category[];
 }
 
-const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
-  pill: Pill,
-  heart: Heart,
-  thermometer: Thermometer,
-  stomach: Car,
-  droplet: Droplet,
-  baby: Baby,
-};
-
 const CategoryFilter: React.FC<CategoryFilterProps> = ({
   selectedCategory,
   onCategoryChange,
   categories,
 }) => {
   const { t, language } = useLanguage();
-
-  const getCategoryName = (category: Category) => {
-    if (language === "en") {
-      const categoryMap: Record<string, string> = {
-        Обезболяващи: "Painkillers",
-        Витамини: "Vitamins",
-        "Простуда и грип": "Cold & Flu",
-        "Стомашно-чревни": "Digestive",
-        "Кожа и коса": "Skin & Hair",
-        "Детски продукти": "Children",
-      };
-      return categoryMap[category.name] || category.name;
-    }
-    return category.name;
-  };
 
   return (
     <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 mb-8">
@@ -90,7 +60,7 @@ const CategoryFilter: React.FC<CategoryFilterProps> = ({
 
         {/* Category Buttons */}
         {categories.map((category) => {
-          const IconComponent = iconMap[category.icon] || Heart;
+          const IconComponent = getCategoryIcon(category.icon);
           return (
             <button
               key={category.id}
@@ -117,7 +87,7 @@ const CategoryFilter: React.FC<CategoryFilterProps> = ({
                 />
               </div>
               <span className="text-sm font-semibold leading-tight">
-                {getCategoryName(category)}
+                {getCategoryDisplayName(category, language)}
               </span>
             </button>
           );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -53,13 +53,13 @@ const Header: React.FC<HeaderProps> = ({
 
   const navigationItems = [
     {
-      key: 'categories',
-      label: t('navigation.categories'),
+      key: 'navigation.categories',
+      path: '/categories',
       onClick: onNavigateToCategories,
     },
     {
-      key: 'products',
-      label: t('navigation.products'),
+      key: 'navigation.products',
+      path: '/products',
       onClick: onNavigateToProducts,
     },
   ];
@@ -213,16 +213,26 @@ const Header: React.FC<HeaderProps> = ({
 
         {/* Desktop navigation */}
         <nav className="hidden md:flex items-center space-x-2 border-t border-gray-100 py-3 text-sm font-medium text-gray-600">
-          {navigationItems.map((item) => (
-            <button
-              key={item.key}
-              type="button"
-              onClick={() => handleNavigationClick(item.onClick)}
-              className="relative rounded-full px-4 py-2 transition-colors duration-200 hover:bg-emerald-50 hover:text-emerald-700"
-            >
-              {item.label}
-            </button>
-          ))}
+          {navigationItems.map((item) => {
+            const isActive =
+              location.pathname === item.path ||
+              (item.path !== '/' && location.pathname.startsWith(`${item.path}/`));
+
+            return (
+              <button
+                key={item.key}
+                type="button"
+                onClick={() => handleNavigationClick(item.onClick)}
+                className={`relative rounded-full px-4 py-2 transition-colors duration-200 ${
+                  isActive
+                    ? 'bg-emerald-50 text-emerald-700'
+                    : 'hover:bg-emerald-50 hover:text-emerald-700'
+                }`}
+              >
+                {t(item.key)}
+              </button>
+            );
+          })}
         </nav>
 
         {/* Mobile search */}
@@ -243,7 +253,25 @@ const Header: React.FC<HeaderProps> = ({
       {/* Mobile menu */}
       {isMenuOpen && (
         <div className="md:hidden bg-white border-t border-gray-100 py-4 px-4 space-y-3">
-          {[{ key: 'categories.title', path: '/' }, ...quickLinks].map((link) => (
+          {navigationItems.map((item) => {
+            const isActive =
+              location.pathname === item.path ||
+              (item.path !== '/' && location.pathname.startsWith(`${item.path}/`));
+
+            return (
+              <button
+                key={item.key}
+                type="button"
+                onClick={() => handleNavigationClick(item.onClick)}
+                className={`block w-full text-left py-2 text-base font-semibold transition-colors ${
+                  isActive ? 'text-emerald-600' : 'text-gray-700 hover:text-emerald-600'
+                }`}
+              >
+                {t(item.key)}
+              </button>
+            );
+          })}
+          {quickLinks.map((link) => (
             <Link
               key={link.key}
               to={link.path}

--- a/src/components/pages/CategoriesPage.tsx
+++ b/src/components/pages/CategoriesPage.tsx
@@ -1,0 +1,101 @@
+import React, { useMemo } from 'react';
+import { ArrowRightCircle } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+
+import { useLanguage } from '../../context/LanguageContext';
+import { Category, Product } from '../../types';
+import { getCategoryDisplayName, getCategoryIcon } from '../../utils/categories';
+
+interface CategoriesPageProps {
+  categories: Category[];
+  products: Product[];
+  onCategorySelect: (categoryId: number | null) => void;
+}
+
+const CategoriesPage: React.FC<CategoriesPageProps> = ({ categories, products, onCategorySelect }) => {
+  const { t, language } = useLanguage();
+  const navigate = useNavigate();
+
+  const categorySummaries = useMemo(
+    () =>
+      categories.map((category) => ({
+        ...category,
+        translatedName: getCategoryDisplayName(category, language),
+        count: products.filter((product) => product.categoryId === category.id).length,
+      })),
+    [categories, language, products],
+  );
+
+  const handleCategoryClick = (categoryId: number) => {
+    onCategorySelect(categoryId);
+  };
+
+  const handleViewAllProducts = () => {
+    onCategorySelect(null);
+    navigate('/products');
+  };
+
+  return (
+    <div className="bg-gray-50 py-12">
+      <div className="container mx-auto px-4 space-y-12">
+        <section className="bg-white rounded-3xl shadow-sm border border-gray-100 p-8 lg:p-12">
+          <div className="max-w-3xl space-y-4">
+            <h1 className="text-4xl font-bold text-gray-900">{t('categories.title')}</h1>
+            <p className="text-lg text-gray-600 leading-relaxed">{t('categories.subtitle')}</p>
+          </div>
+
+          <div className="mt-8 flex flex-wrap items-center gap-4">
+            <span className="inline-flex items-center px-4 py-2 rounded-full bg-emerald-50 text-emerald-700 font-semibold">
+              {categories.length} {t('categories.title').toLowerCase()}
+            </span>
+            <span className="inline-flex items-center px-4 py-2 rounded-full bg-sky-50 text-sky-700 font-semibold">
+              {products.length} {t('products.products')}
+            </span>
+          </div>
+        </section>
+
+        <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {categorySummaries.map((category) => {
+            const IconComponent = getCategoryIcon(category.icon);
+
+            return (
+              <button
+                key={category.id}
+                type="button"
+                onClick={() => handleCategoryClick(category.id)}
+                className="text-left bg-white border border-gray-200 hover:border-emerald-300 hover:shadow-lg transition-all duration-300 rounded-2xl p-6 group"
+              >
+                <div className="flex items-center justify-between mb-4">
+                  <div className="w-12 h-12 rounded-xl bg-emerald-50 text-emerald-600 flex items-center justify-center group-hover:bg-emerald-100">
+                    <IconComponent className="w-6 h-6" />
+                  </div>
+                  <span className="text-sm font-semibold text-emerald-600">
+                    {category.count} {t('products.products')}
+                  </span>
+                </div>
+                <h3 className="text-xl font-semibold text-gray-900 mb-2">{category.translatedName}</h3>
+                <p className="text-sm text-gray-500 leading-relaxed mb-4">{category.description}</p>
+                <span className="inline-flex items-center text-sm font-semibold text-emerald-600 group-hover:text-emerald-700">
+                  {t('categories.viewProducts')}
+                  <ArrowRightCircle className="w-4 h-4 ml-2 transition-transform duration-300 group-hover:translate-x-1" />
+                </span>
+              </button>
+            );
+          })}
+        </section>
+
+        <section className="text-center">
+          <button
+            type="button"
+            onClick={handleViewAllProducts}
+            className="inline-flex items-center justify-center px-6 py-3 rounded-full bg-emerald-600 text-white font-semibold hover:bg-emerald-700 transition-colors"
+          >
+            {t('products.viewAll')}
+          </button>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default CategoriesPage;

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
 import HeroSection from '../HeroSection';
 import CategoryFilter from '../CategoryFilter';
 import ProductGrid from '../ProductGrid';
 import { useLanguage } from '../../context/LanguageContext';
 import { Category, Product } from '../../types';
+import { getCategoryDisplayName, getCategoryIcon } from '../../utils/categories';
 
 interface HomePageProps {
   searchTerm: string;
@@ -12,6 +15,7 @@ interface HomePageProps {
   filteredProducts: Product[];
   categories: Category[];
   showHero: boolean;
+  allProducts: Product[];
 }
 
 const HomePage: React.FC<HomePageProps> = ({
@@ -20,44 +24,123 @@ const HomePage: React.FC<HomePageProps> = ({
   onCategoryChange,
   filteredProducts,
   categories,
-  showHero
+  showHero,
+  allProducts,
 }) => {
-  const { t } = useLanguage();
+  const { t, language } = useLanguage();
+  const navigate = useNavigate();
+
+  const selectedCategoryEntity = selectedCategory
+    ? categories.find((category) => category.id === selectedCategory)
+    : undefined;
+  const selectedCategoryLabel = selectedCategoryEntity
+    ? getCategoryDisplayName(selectedCategoryEntity, language)
+    : t('products.unknown');
 
   const resultsTitle = searchTerm
     ? `${t('products.resultsFor')} "${searchTerm}"`
     : selectedCategory
-    ? `${t('products.category')}: ${
-        categories.find((category) => category.id === selectedCategory)?.name ||
-        t('products.unknown')
-      }`
+    ? `${t('products.category')}: ${selectedCategoryLabel}`
     : t('products.allProducts');
+
+  const showPreview = showHero;
+  const previewCategories = categories.slice(0, 4);
+  const previewProducts = allProducts.slice(0, 4);
+
+  const handleViewAllCategories = () => {
+    navigate('/categories');
+  };
+
+  const handleViewAllProducts = () => {
+    navigate('/products');
+  };
 
   return (
     <div className="bg-gray-50">
       {showHero && <HeroSection />}
 
       <main className="container mx-auto px-4 py-8 bg-white min-h-screen">
-        <section id="category-filter">
-          <CategoryFilter
-            selectedCategory={selectedCategory}
-            onCategoryChange={onCategoryChange}
-            categories={categories}
-          />
-        </section>
+        {showPreview ? (
+          <>
+            <section className="mb-12">
+              <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+                <div>
+                  <h2 className="text-3xl font-bold text-gray-900">{t('categories.title')}</h2>
+                  <p className="text-gray-600">{t('categories.previewSubtitle')}</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={handleViewAllCategories}
+                  className="inline-flex items-center justify-center px-5 py-2 rounded-full border border-emerald-200 text-sm font-semibold text-emerald-700 hover:border-emerald-300 hover:text-emerald-800 transition-colors"
+                >
+                  {t('categories.viewAll')}
+                </button>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                {previewCategories.map((category) => {
+                  const IconComponent = getCategoryIcon(category.icon);
 
-        {(searchTerm || selectedCategory) && (
-          <div className="mb-8 bg-white rounded-2xl shadow-sm border border-gray-100 p-6">
-            <h2 className="text-2xl font-bold text-gray-900 mb-2">{resultsTitle}</h2>
-            <p className="text-gray-600 flex items-center">
-              <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-emerald-100 text-emerald-800">
-                {filteredProducts.length} {t('products.products')}
-              </span>
-            </p>
-          </div>
+                  return (
+                    <button
+                      key={category.id}
+                      type="button"
+                      onClick={() => onCategoryChange(category.id)}
+                      className="text-left bg-white border border-gray-200 hover:border-emerald-300 hover:shadow-lg transition-all duration-300 rounded-2xl p-5 group"
+                    >
+                      <div className="w-12 h-12 rounded-xl bg-emerald-50 text-emerald-600 flex items-center justify-center mb-4 group-hover:bg-emerald-100">
+                        <IconComponent className="w-6 h-6" />
+                      </div>
+                      <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                        {getCategoryDisplayName(category, language)}
+                      </h3>
+                      <p className="text-sm text-gray-500 leading-relaxed">{category.description}</p>
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+
+            <section>
+              <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+                <div>
+                  <h2 className="text-3xl font-bold text-gray-900">{t('products.featuredTitle')}</h2>
+                  <p className="text-gray-600">{t('products.featuredSubtitle')}</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={handleViewAllProducts}
+                  className="inline-flex items-center justify-center px-5 py-2 rounded-full border border-emerald-200 text-sm font-semibold text-emerald-700 hover:border-emerald-300 hover:text-emerald-800 transition-colors"
+                >
+                  {t('products.viewAll')}
+                </button>
+              </div>
+              <ProductGrid products={previewProducts} isLoading={false} />
+            </section>
+          </>
+        ) : (
+          <>
+            <section id="category-filter">
+              <CategoryFilter
+                selectedCategory={selectedCategory}
+                onCategoryChange={onCategoryChange}
+                categories={categories}
+              />
+            </section>
+
+            {(searchTerm || selectedCategory) && (
+              <div className="mb-8 bg-white rounded-2xl shadow-sm border border-gray-100 p-6">
+                <h2 className="text-2xl font-bold text-gray-900 mb-2">{resultsTitle}</h2>
+                <p className="text-gray-600 flex items-center">
+                  <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-emerald-100 text-emerald-800">
+                    {filteredProducts.length} {t('products.products')}
+                  </span>
+                </p>
+              </div>
+            )}
+
+            <ProductGrid products={filteredProducts} isLoading={false} />
+          </>
         )}
-
-        <ProductGrid products={filteredProducts} isLoading={false} />
       </main>
     </div>
   );

--- a/src/components/pages/ProductsPage.tsx
+++ b/src/components/pages/ProductsPage.tsx
@@ -1,9 +1,10 @@
 import React, { useMemo } from 'react';
-import { CheckCircle, Baby, Car, Droplet, Heart, Pill, Thermometer } from 'lucide-react';
-import CategoryFilter from '../CategoryFilter';
+import { CheckCircle } from 'lucide-react';
+
 import ProductGrid from '../ProductGrid';
-import { useLanguage, Language } from '../../context/LanguageContext';
+import { useLanguage } from '../../context/LanguageContext';
 import { Category, Product } from '../../types';
+import { getCategoryDisplayName, getCategoryIcon } from '../../utils/categories';
 
 interface ProductsPageProps {
   searchTerm: string;
@@ -14,38 +15,13 @@ interface ProductsPageProps {
   allProducts: Product[];
 }
 
-const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
-  pill: Pill,
-  heart: Heart,
-  thermometer: Thermometer,
-  stomach: Car,
-  droplet: Droplet,
-  baby: Baby
-};
-
-const getCategoryName = (category: Category, language: Language) => {
-  if (language === 'en') {
-    const categoryMap: Record<string, string> = {
-      'Обезболяващи': 'Painkillers',
-      Витамини: 'Vitamins',
-      'Простуда и грип': 'Cold & Flu',
-      'Стомашно-чревни': 'Digestive',
-      'Кожа и коса': 'Skin & Hair',
-      'Детски продукти': 'Children'
-    };
-    return categoryMap[category.name] || category.name;
-  }
-
-  return category.name;
-};
-
 const ProductsPage: React.FC<ProductsPageProps> = ({
   searchTerm,
   selectedCategory,
   onCategoryChange,
   filteredProducts,
   categories,
-  allProducts
+  allProducts,
 }) => {
   const { t, language } = useLanguage();
 
@@ -53,10 +29,10 @@ const ProductsPage: React.FC<ProductsPageProps> = ({
     () =>
       categories.map((category) => ({
         ...category,
-        translatedName: getCategoryName(category, language),
-        count: allProducts.filter((product) => product.categoryId === category.id).length
+        translatedName: getCategoryDisplayName(category, language),
+        count: allProducts.filter((product) => product.categoryId === category.id).length,
       })),
-    [allProducts, categories, language]
+    [allProducts, categories, language],
   );
 
   const hasActiveFilters = Boolean(searchTerm || selectedCategory);
@@ -64,7 +40,7 @@ const ProductsPage: React.FC<ProductsPageProps> = ({
     ? categories.find((category) => category.id === selectedCategory)
     : undefined;
   const selectedCategoryLabel = selectedCategoryEntity
-    ? getCategoryName(selectedCategoryEntity, language)
+    ? getCategoryDisplayName(selectedCategoryEntity, language)
     : t('products.unknown');
 
   const resultsTitle = searchTerm
@@ -79,9 +55,7 @@ const ProductsPage: React.FC<ProductsPageProps> = ({
         <section className="bg-white rounded-3xl shadow-sm border border-gray-100 p-8 lg:p-12">
           <div className="max-w-3xl">
             <h1 className="text-4xl font-bold text-gray-900 mb-4">{t('products.catalogTitle')}</h1>
-            <p className="text-lg text-gray-600 leading-relaxed">
-              {t('products.catalogDescription')}
-            </p>
+            <p className="text-lg text-gray-600 leading-relaxed">{t('products.catalogDescription')}</p>
           </div>
 
           <div className="mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
@@ -92,26 +66,39 @@ const ProductsPage: React.FC<ProductsPageProps> = ({
             </div>
 
             {categorySummaries.map((category) => {
-              const IconComponent = iconMap[category.icon] || Pill;
+              const IconComponent = getCategoryIcon(category.icon);
+              const isSelected = selectedCategory === category.id;
 
               return (
                 <button
                   key={category.id}
                   type="button"
                   onClick={() => onCategoryChange(category.id)}
-                  className="text-left bg-white border border-gray-200 hover:border-emerald-300 hover:shadow-md transition-all duration-200 rounded-2xl p-6 group"
+                  className={`text-left border rounded-2xl p-6 group transition-all duration-200 ${
+                    isSelected
+                      ? 'bg-emerald-50 border-emerald-200 shadow-md'
+                      : 'bg-white border-gray-200 hover:border-emerald-300 hover:shadow-md'
+                  }`}
                 >
                   <div className="flex items-center justify-between mb-4">
-                    <div className="w-12 h-12 rounded-xl bg-emerald-50 text-emerald-600 flex items-center justify-center group-hover:bg-emerald-100">
+                    <div
+                      className={`w-12 h-12 rounded-xl flex items-center justify-center ${
+                        isSelected
+                          ? 'bg-emerald-500 text-white'
+                          : 'bg-emerald-50 text-emerald-600 group-hover:bg-emerald-100'
+                      }`}
+                    >
                       <IconComponent className="w-6 h-6" />
                     </div>
-                    <span className="text-sm font-semibold text-emerald-600">
+                    <span
+                      className={`text-sm font-semibold ${
+                        isSelected ? 'text-emerald-700' : 'text-emerald-600'
+                      }`}
+                    >
                       {category.count} {t('products.products')}
                     </span>
                   </div>
-                  <h3 className="text-lg font-semibold text-gray-900 mb-2">
-                    {category.translatedName}
-                  </h3>
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">{category.translatedName}</h3>
                   <p className="text-sm text-gray-500 leading-relaxed">
                     {t('products.inCategory')} {category.translatedName}
                   </p>
@@ -122,12 +109,6 @@ const ProductsPage: React.FC<ProductsPageProps> = ({
         </section>
 
         <section>
-          <CategoryFilter
-            selectedCategory={selectedCategory}
-            onCategoryChange={onCategoryChange}
-            categories={categories}
-          />
-
           {(hasActiveFilters || filteredProducts.length > 0) && (
             <div className="mb-8 bg-white rounded-2xl shadow-sm border border-gray-100 p-6">
               <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -45,6 +45,10 @@ const translations = {
 
     // Categories
     'categories.title': 'Категории',
+    'categories.subtitle': 'Разгледайте нашите основни категории и открийте подходящите продукти.',
+    'categories.previewSubtitle': 'Бърз поглед към някои от най-популярните ни категории.',
+    'categories.viewAll': 'Виж всички категории',
+    'categories.viewProducts': 'Виж продуктите',
     'categories.all': 'Всички',
     'categories.painkillers': 'Обезболяващи',
     'categories.vitamins': 'Витамини',
@@ -396,6 +400,10 @@ const translations = {
 
     // Categories
     'categories.title': 'Categories',
+    'categories.subtitle': 'Explore our main categories and find the right treatments.',
+    'categories.previewSubtitle': 'Take a quick look at some of our most popular categories.',
+    'categories.viewAll': 'View all categories',
+    'categories.viewProducts': 'View products',
     'categories.all': 'All',
     'categories.painkillers': 'Painkillers',
     'categories.vitamins': 'Vitamins',

--- a/src/utils/categories.ts
+++ b/src/utils/categories.ts
@@ -1,0 +1,35 @@
+import type { LucideIcon } from 'lucide-react';
+import { Pill, Heart, Thermometer, Car, Droplet, Baby } from 'lucide-react';
+
+import type { Category } from '../types';
+import type { Language } from '../context/LanguageContext';
+
+const categoryIconMap: Record<string, LucideIcon> = {
+  pill: Pill,
+  heart: Heart,
+  thermometer: Thermometer,
+  stomach: Car,
+  droplet: Droplet,
+  baby: Baby,
+};
+
+const categoryNameTranslations: Record<string, string> = {
+  'Обезболяващи': 'Painkillers',
+  Витамини: 'Vitamins',
+  'Простуда и грип': 'Cold & Flu',
+  'Стомашно-чревни': 'Digestive',
+  'Кожа и коса': 'Skin & Hair',
+  'Детски продукти': 'Children',
+};
+
+export const getCategoryIcon = (iconKey: string): LucideIcon => {
+  return categoryIconMap[iconKey] || Heart;
+};
+
+export const getCategoryDisplayName = (category: Category, language: Language): string => {
+  if (language === 'en') {
+    return categoryNameTranslations[category.name] || category.name;
+  }
+
+  return category.name;
+};


### PR DESCRIPTION
## Summary
- add a dedicated categories page with translated category cards that link to filtered product results
- refresh the home page to highlight a small set of featured categories and products when no filters are applied
- update header navigation and route handling so menu and footer links open the correct pages and scroll to the top automatically

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0788fc22c8331b5061689e475c541