### PR TITLE
Improve cart context and UI localization

### DIFF
--- a/src/components/CartDrawer.tsx
+++ b/src/components/CartDrawer.tsx
@@ -1,11 +1,21 @@
 import React from 'react';
 import { X, Plus, Minus, ShoppingBag, CreditCard } from 'lucide-react';
 import { useCart } from '../context/CartContext';
+import { useLanguage } from '../context/LanguageContext';
+import type { Product } from '../types';
 
 const CartDrawer: React.FC = () => {
   const { state, dispatch } = useCart();
+  const { language, t } = useLanguage();
 
-  if (!state.isOpen) return null;
+  const getProductName = (product: Product) =>
+    language === 'bg' ? product.name : product.nameEn;
+  const getActiveIngredient = (product: Product) =>
+    language === 'bg' ? product.activeIngredient : product.activeIngredientEn;
+  const getDosage = (product: Product) =>
+    language === 'bg' ? product.dosage : product.dosageEn;
+  const getManufacturer = (product: Product) =>
+    language === 'bg' ? product.manufacturer : product.manufacturerEn;
 
   const updateQuantity = (id: number, quantity: number) => {
     dispatch({ type: 'UPDATE_QUANTITY', payload: { id, quantity } });
@@ -15,85 +25,112 @@ const CartDrawer: React.FC = () => {
     dispatch({ type: 'REMOVE_ITEM', payload: id });
   };
 
+  const freeDeliveryThreshold = 25;
+  const freeDeliveryMessage =
+    state.total >= freeDeliveryThreshold
+      ? t('cart.freeDelivery')
+      : t('cart.addForFreeDelivery').replace(
+          '{amount}',
+          Math.max(0, freeDeliveryThreshold - state.total).toFixed(2),
+        );
+
+  if (!state.isOpen) return null;
+
   return (
     <>
       {/* Backdrop */}
-      <div 
-        className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 animate-fade-in"
+      <div
+        className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm animate-fade-in"
         onClick={() => dispatch({ type: 'SET_CART_OPEN', payload: false })}
       />
 
       {/* Drawer */}
-      <div className="fixed right-0 top-0 h-full w-full max-w-md bg-white shadow-2xl z-50 animate-slide-in flex flex-col">
+      <div className="fixed right-0 top-0 z-50 flex h-full w-full max-w-md flex-col bg-white shadow-2xl animate-slide-in">
         {/* Header */}
-        <div className="flex items-center justify-between p-6 border-b border-gray-200">
+        <div className="flex items-center justify-between border-b border-gray-200 p-6">
           <div className="flex items-center space-x-2">
-            <ShoppingBag className="w-6 h-6 text-primary-600" />
-            <h2 className="text-xl font-display font-semibold text-gray-900">
-              Количка ({state.itemCount})
+            <ShoppingBag className="h-6 w-6 text-primary-600" />
+            <h2 className="font-display text-xl font-semibold text-gray-900">
+              {t('cart.title')} ({state.itemCount})
             </h2>
           </div>
           <button
+            type="button"
             onClick={() => dispatch({ type: 'SET_CART_OPEN', payload: false })}
-            className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+            className="rounded-lg p-2 transition-colors hover:bg-gray-100"
           >
-            <X className="w-5 h-5" />
+            <X className="h-5 w-5" />
           </button>
         </div>
 
         {/* Content */}
         <div className="flex-1 overflow-y-auto">
           {state.items.length === 0 ? (
-            <div className="flex flex-col items-center justify-center h-full text-center p-6">
-              <div className="bg-gray-100 rounded-full w-24 h-24 flex items-center justify-center mb-6">
-                <ShoppingBag className="w-12 h-12 text-gray-400" />
+            <div className="flex h-full flex-col items-center justify-center p-6 text-center">
+              <div className="mb-6 flex h-24 w-24 items-center justify-center rounded-full bg-gray-100">
+                <ShoppingBag className="h-12 w-12 text-gray-400" />
               </div>
-              <h3 className="text-lg font-display font-semibold text-gray-900 mb-2">
-                Количката е празна
+              <h3 className="font-display mb-2 text-lg font-semibold text-gray-900">
+                {t('cart.empty')}
               </h3>
-              <p className="text-gray-600 mb-6">
-                Добавете продукти, за да продължите с поръчката
+              <p className="mb-6 text-gray-600">
+                {t('cart.emptyDescription')}
               </p>
               <button
+                type="button"
                 onClick={() => dispatch({ type: 'SET_CART_OPEN', payload: false })}
-                className="bg-primary-500 hover:bg-primary-600 text-white font-medium py-3 px-6 rounded-xl transition-all duration-200"
+                className="rounded-xl bg-primary-500 px-6 py-3 font-medium text-white transition-all duration-200 hover:bg-primary-600"
               >
-                Продължете пазаруването
+                {t('cart.continueShopping')}
               </button>
             </div>
           ) : (
-            <div className="p-6 space-y-4">
+            <div className="space-y-4 p-6">
               {state.items.map((item) => (
-                <div key={item.id} className="bg-gray-50 rounded-xl p-4">
+                <div key={item.id} className="rounded-xl bg-gray-50 p-4">
                   <div className="flex items-start space-x-4">
                     <img
                       src={item.product.imageUrl}
-                      alt={item.product.name}
-                      className="w-16 h-16 rounded-lg object-cover"
+                      alt={getProductName(item.product)}
+                      className="h-16 w-16 rounded-lg object-cover"
                     />
                     <div className="flex-1">
-                      <h4 className="font-display font-medium text-gray-900 mb-1">
-                        {item.product.name}
+                      <h4 className="font-display mb-1 font-medium text-gray-900">
+                        {getProductName(item.product)}
                       </h4>
-                      <p className="text-sm text-gray-600 mb-2">
-                        {item.product.activeIngredient}
-                      </p>
+                      {getActiveIngredient(item.product) && (
+                        <p className="mb-2 text-sm text-gray-600">
+                          {getActiveIngredient(item.product)}
+                        </p>
+                      )}
+                      {getDosage(item.product) && (
+                        <p className="mb-2 text-sm text-gray-600">
+                          {getDosage(item.product)}
+                        </p>
+                      )}
+                      {getManufacturer(item.product) && (
+                        <p className="mb-2 text-sm text-gray-600">
+                          {getManufacturer(item.product)}
+                        </p>
+                      )}
                       <div className="flex items-center justify-between">
                         <div className="flex items-center space-x-3">
                           <button
+                            type="button"
                             onClick={() => updateQuantity(item.id, item.quantity - 1)}
-                            className="w-8 h-8 rounded-full bg-white border border-gray-300 flex items-center justify-center hover:border-primary-500 hover:text-primary-600 transition-colors"
+                            className="flex h-8 w-8 items-center justify-center rounded-full border border-gray-300 bg-white transition-colors hover:border-primary-500 hover:text-primary-600"
                           >
-                            <Minus className="w-4 h-4" />
+                            <Minus className="h-4 w-4" />
                           </button>
-                          <span className="font-medium text-gray-900 min-w-[2rem] text-center">
+                          <span className="min-w-[2rem] text-center font-medium text-gray-900">
                             {item.quantity}
                           </span>
                           <button
+                            type="button"
                             onClick={() => updateQuantity(item.id, item.quantity + 1)}
-                            className="w-8 h-8 rounded-full bg-white border border-gray-300 flex items-center justify-center hover:border-primary-500 hover:text-primary-600 transition-colors"
+                            className="flex h-8 w-8 items-center justify-center rounded-full border border-gray-300 bg-white transition-colors hover:border-primary-500 hover:text-primary-600"
                           >
-                            <Plus className="w-4 h-4" />
+                            <Plus className="h-4 w-4" />
                           </button>
                         </div>
                         <div className="text-right">
@@ -101,10 +138,11 @@ const CartDrawer: React.FC = () => {
                             €{(item.unitPrice * item.quantity).toFixed(2)}
                           </p>
                           <button
+                            type="button"
                             onClick={() => removeItem(item.id)}
-                            className="text-sm text-red-600 hover:text-red-700 transition-colors"
+                            className="text-sm text-red-600 transition-colors hover:text-red-700"
                           >
-                            Премахни
+                            {t('cart.remove')}
                           </button>
                         </div>
                       </div>
@@ -118,35 +156,33 @@ const CartDrawer: React.FC = () => {
 
         {/* Footer */}
         {state.items.length > 0 && (
-          <div className="border-t border-gray-200 p-6 space-y-4">
+          <div className="space-y-4 border-t border-gray-200 p-6">
             {/* Total */}
-            <div className="flex items-center justify-between text-lg font-display font-semibold">
-              <span>Общо:</span>
+            <div className="font-display flex items-center justify-between text-lg font-semibold">
+              <span>{t('cart.total')}:</span>
               <span className="text-primary-600">€{state.total.toFixed(2)}</span>
             </div>
 
             {/* Delivery info */}
-            <div className="text-sm text-gray-600 bg-green-50 p-3 rounded-lg">
-              {state.total >= 25 ? (
-                <span className="text-green-700">✓ Безплатна доставка</span>
-              ) : (
-                <span>
-                  Добавете продукти за €{(25 - state.total).toFixed(2)} за безплатна доставка
-                </span>
-              )}
+            <div className="rounded-lg bg-green-50 p-3 text-sm text-gray-600">
+              <span className="text-green-700">{freeDeliveryMessage}</span>
             </div>
 
             {/* Actions */}
             <div className="space-y-3">
-              <button className="w-full bg-primary-500 hover:bg-primary-600 text-white font-medium py-4 px-6 rounded-xl transition-all duration-200 flex items-center justify-center space-x-2">
-                <CreditCard className="w-5 h-5" />
-                <span>Финализиране на поръчка</span>
+              <button
+                type="button"
+                className="flex w-full items-center justify-center space-x-2 rounded-xl bg-primary-500 px-6 py-4 font-medium text-white transition-all duration-200 hover:bg-primary-600"
+              >
+                <CreditCard className="h-5 w-5" />
+                <span>{t('cart.checkout')}</span>
               </button>
               <button
+                type="button"
                 onClick={() => dispatch({ type: 'SET_CART_OPEN', payload: false })}
-                className="w-full bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium py-3 px-6 rounded-xl transition-colors"
+                className="w-full rounded-xl bg-gray-100 px-6 py-3 font-medium text-gray-700 transition-colors hover:bg-gray-200"
               >
-                Продължете пазаруването
+                {t('cart.continueShopping')}
               </button>
             </div>
           </div>

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,16 +1,9 @@
-import React from "react";
-import {
-  ShoppingCart,
-  Star,
-  MessageCircle,
-  Shield,
-  Heart,
-  Package,
-} from "lucide-react";
-import { Product } from "../types";
-import { useCart } from "../context/CartContext";
-import { useChat } from "../context/ChatContext";
-import { useLanguage } from "../context/LanguageContext";
+import React from 'react';
+import { ShoppingCart, Star, MessageCircle, Shield, Heart, Package } from 'lucide-react';
+import { Product } from '../types';
+import { useCart } from '../context/CartContext';
+import { useChat } from '../context/ChatContext';
+import { useLanguage } from '../context/LanguageContext';
 
 interface ProductCardProps {
   product: Product;
@@ -21,119 +14,115 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
   const { askAssistant } = useChat();
   const { language, t } = useLanguage();
 
-  const handleAddToCart = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    dispatch({ type: "ADD_ITEM", payload: product });
+  const rating = Math.min(5, Math.max(0, product.rating ?? 0));
+  const reviewCount = product.reviewCount ?? 0;
+
+  const handleAddToCart = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    dispatch({ type: 'ADD_ITEM', payload: product });
   };
 
-  const handleAskAI = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    const productName = language === "bg" ? product.name : product.nameEn;
+  const handleAskAI = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    const productName = language === 'bg' ? product.name : product.nameEn;
     const question =
-      language === "bg"
-        ? `Разкажете ми за ${productName}`
-        : `Tell me about ${productName}`;
+      language === 'bg' ? `Разкажете ми за ${productName}` : `Tell me about ${productName}`;
 
     if (product.id) {
-      askAssistant(question, product.id);
+      void askAssistant(question, product.id);
     }
   };
 
-  const getProductName = () =>
-    language === "bg" ? product.name : product.nameEn;
+  const getProductName = () => (language === 'bg' ? product.name : product.nameEn);
   const getActiveIngredient = () =>
-    language === "bg" ? product.activeIngredient : product.activeIngredientEn;
-  const getDosage = () =>
-    language === "bg" ? product.dosage : product.dosageEn;
+    language === 'bg' ? product.activeIngredient : product.activeIngredientEn;
+  const getDosage = () => (language === 'bg' ? product.dosage : product.dosageEn);
   const getManufacturer = () =>
-    language === "bg" ? product.manufacturer : product.manufacturerEn;
+    language === 'bg' ? product.manufacturer : product.manufacturerEn;
 
   return (
-    <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden group hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
+    <div className="group overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg">
       {/* Image */}
       <div className="relative aspect-square overflow-hidden bg-gray-50">
         <img
           src={product.imageUrl}
           alt={getProductName()}
-          className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+          className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
         />
         {product.requiresPrescription && (
-          <div className="absolute top-3 left-3 bg-red-500 text-white text-xs font-bold px-2 py-1 rounded-full flex items-center space-x-1">
-            <Shield className="w-3 h-3" />
-            <span>{t("products.prescription")}</span>
+          <div className="absolute left-3 top-3 flex items-center space-x-1 rounded-full bg-red-500 px-2 py-1 text-xs font-bold text-white">
+            <Shield className="h-3 w-3" />
+            <span>{t('products.prescription')}</span>
           </div>
         )}
-        <button className="absolute top-3 right-3 p-2 bg-white/90 hover:bg-white rounded-full shadow-md opacity-0 group-hover:opacity-100 transition-all duration-300 hover:scale-110">
-          <Heart className="w-4 h-4 text-gray-600 hover:text-red-500 transition-colors duration-200" />
+        <button
+          type="button"
+          className="absolute right-3 top-3 rounded-full bg-white/90 p-2 opacity-0 shadow-md transition-all duration-300 hover:scale-110 hover:bg-white group-hover:opacity-100"
+        >
+          <Heart className="h-4 w-4 text-gray-600 transition-colors duration-200 hover:text-red-500" />
         </button>
 
         {/* Stock indicator */}
         <div
-          className={`absolute bottom-3 left-3 px-2 py-1 rounded-full text-xs font-medium ${
+          className={`absolute bottom-3 left-3 rounded-full px-2 py-1 text-xs font-medium ${
             product.stockQuantity > 10
-              ? "bg-green-100 text-green-800"
+              ? 'bg-green-100 text-green-800'
               : product.stockQuantity > 0
-              ? "bg-yellow-100 text-yellow-800"
-              : "bg-red-100 text-red-800"
+              ? 'bg-yellow-100 text-yellow-800'
+              : 'bg-red-100 text-red-800'
           }`}
         >
-          <Package className="w-3 h-3 inline mr-1" />
+          <Package className="mr-1 inline h-3 w-3" />
           {product.stockQuantity > 10
-            ? t("products.inStock")
+            ? t('products.inStock')
             : product.stockQuantity > 0
-            ? `${product.stockQuantity} ${t("products.pieces")}`
-            : t("products.outOfStock")}
+            ? `${product.stockQuantity} ${t('products.pieces')}`
+            : t('products.outOfStock')}
         </div>
       </div>
 
       {/* Content */}
       <div className="p-5">
-       {/* Rating */}
-{product.rating !== undefined && (
-  <div className="flex items-center space-x-1 mb-3">
-    <div className="flex items-center">
-      {[...Array(5)].map((_, i) => (
-        <Star
-          key={i}
-          className={`w-4 h-4 ${
-            i < Math.floor(product.rating ?? 0)
-              ? "text-yellow-400 fill-current"
-              : "text-gray-300"
-          }`}
-        />
-      ))}
-    </div>
-    <span className="text-sm text-gray-500">
-      ({product.reviewCount ?? 0})
-    </span>
-  </div>
-)}
-
+        {product.rating !== undefined && (
+          <div className="mb-3 flex items-center space-x-1">
+            <div className="flex items-center">
+              {Array.from({ length: 5 }).map((_, index) => (
+                <Star
+                  key={index}
+                  className={`h-4 w-4 ${
+                    index < Math.floor(rating)
+                      ? 'fill-current text-yellow-400'
+                      : 'text-gray-300'
+                  }`}
+                />
+              ))}
+            </div>
+            <span className="text-sm text-gray-500">({reviewCount})</span>
+          </div>
+        )}
 
         {/* Title */}
-        <h3 className="font-bold text-gray-900 mb-2 line-clamp-2 group-hover:text-emerald-600 transition-colors duration-300">
+        <h3 className="mb-2 line-clamp-2 font-bold text-gray-900 transition-colors duration-300 group-hover:text-emerald-600">
           {getProductName()}
         </h3>
 
         {/* Details */}
-        <div className="space-y-1 mb-4 text-sm text-gray-600">
+        <div className="mb-4 space-y-1 text-sm text-gray-600">
           {getActiveIngredient() && (
             <p>
-              <span className="font-medium">
-                {t("products.activeIngredient")}:
-              </span>{" "}
+              <span className="font-medium">{t('products.activeIngredient')}:</span>{' '}
               {getActiveIngredient()}
             </p>
           )}
           {getDosage() && (
             <p>
-              <span className="font-medium">{t("products.dosage")}:</span>{" "}
+              <span className="font-medium">{t('products.dosage')}:</span>{' '}
               {getDosage()}
             </p>
           )}
           {getManufacturer() && (
             <p>
-              <span className="font-medium">{t("products.manufacturer")}:</span>{" "}
+              <span className="font-medium">{t('products.manufacturer')}:</span>{' '}
               {getManufacturer()}
             </p>
           )}
@@ -151,15 +140,17 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
           <button
             onClick={handleAddToCart}
             disabled={product.stockQuantity === 0}
-            className="flex-1 bg-emerald-600 hover:bg-emerald-700 disabled:bg-gray-300 disabled:cursor-not-allowed text-white font-semibold py-3 px-4 rounded-xl transition-all duration-300 flex items-center justify-center space-x-2 group/btn hover:scale-105"
+            type="button"
+            className="group/btn flex flex-1 items-center justify-center space-x-2 rounded-xl bg-emerald-600 px-4 py-3 font-semibold text-white transition-all duration-300 hover:scale-105 hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-gray-300"
           >
-            <ShoppingCart className="w-4 h-4 group-hover/btn:scale-110 transition-transform duration-300" />
-            <span>{t("products.add")}</span>
+            <ShoppingCart className="h-4 w-4 transition-transform duration-300 group-hover/btn:scale-110" />
+            <span>{t('products.add')}</span>
           </button>
 
           <button
             onClick={handleAskAI}
-            className="p-3 bg-gray-100 hover:bg-emerald-100 text-gray-600 hover:text-emerald-600 rounded-xl transition-all duration-300 hover:scale-110"
+            type="button"
+            className="rounded-xl bg-gray-100 p-3 text-gray-600 transition-all duration-300 hover:scale-110 hover:bg-emerald-100 hover:text-emerald-600"
           >
             <MessageCircle className="w-5 h-5" />
           </button>

--- a/src/components/ProductGrid.tsx
+++ b/src/components/ProductGrid.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
+import { Package } from 'lucide-react';
 import { Product } from '../types';
 import ProductCard from './ProductCard';
-import { Package } from 'lucide-react';
 import { useLanguage } from '../context/LanguageContext';
 
 interface ProductGridProps {
   products: Product[];
   isLoading?: boolean;
+  onEmptyAction?: () => void;
 }
 
-const ProductGrid: React.FC<ProductGridProps> = ({ products, isLoading = false }) => {
+const ProductGrid: React.FC<ProductGridProps> = ({ products, isLoading = false, onEmptyAction }) => {
   const { t } = useLanguage();
 
   if (isLoading) {
@@ -42,9 +43,15 @@ const ProductGrid: React.FC<ProductGridProps> = ({ products, isLoading = false }
         <p className="text-gray-600 mb-6">
           {t('products.tryDifferent')}
         </p>
-        <button className="bg-emerald-600 hover:bg-emerald-700 text-white font-semibold py-3 px-6 rounded-xl transition-all duration-300 hover:scale-105">
-          {t('products.viewAll')}
-        </button>
+        {onEmptyAction && (
+          <button
+            type="button"
+            onClick={onEmptyAction}
+            className="rounded-xl bg-emerald-600 px-6 py-3 font-semibold text-white transition-all duration-300 hover:scale-105 hover:bg-emerald-700"
+          >
+            {t('products.viewAll')}
+          </button>
+        )}
       </div>
     );
   }

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -114,7 +114,11 @@ const HomePage: React.FC<HomePageProps> = ({
                   {t('products.viewAll')}
                 </button>
               </div>
-              <ProductGrid products={previewProducts} isLoading={false} />
+              <ProductGrid
+                products={previewProducts}
+                isLoading={false}
+                onEmptyAction={handleViewAllProducts}
+              />
             </section>
           </>
         ) : (
@@ -138,7 +142,11 @@ const HomePage: React.FC<HomePageProps> = ({
               </div>
             )}
 
-            <ProductGrid products={filteredProducts} isLoading={false} />
+            <ProductGrid
+              products={filteredProducts}
+              isLoading={false}
+              onEmptyAction={handleViewAllProducts}
+            />
           </>
         )}
       </main>

--- a/src/components/pages/ProductsPage.tsx
+++ b/src/components/pages/ProductsPage.tsx
@@ -134,7 +134,11 @@ const ProductsPage: React.FC<ProductsPageProps> = ({
             </div>
           )}
 
-          <ProductGrid products={filteredProducts} isLoading={false} />
+          <ProductGrid
+            products={filteredProducts}
+            isLoading={false}
+            onEmptyAction={() => onCategoryChange(null)}
+          />
         </section>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- harden the cart context by throwing when used outside its provider, memoizing the value, and centralising total calculations for reducer actions
- localise the cart drawer UI so copy, product details, and free-delivery messaging respect the selected language while standardising button semantics
- tidy product cards and grids to improve rating display, button behaviour, and provide actionable empty states in the home and products pages

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d244ec0714833186d14c620a3ce02a