### PR TITLE
Display localized date and remove demo login info

### DIFF
--- a/src/components/auth/LoginModal.tsx
+++ b/src/components/auth/LoginModal.tsx
@@ -442,35 +442,6 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose, onSwitchToRegi
                   </button>
                 </form>
 
-                <div className="mt-6 p-4 bg-blue-50 rounded-xl">
-                  <h4 className="font-medium text-blue-900 mb-2">{t('auth.demoAccounts')}</h4>
-                  <div className="text-sm text-blue-700 space-y-1">
-                    <p>
-                      <strong>{t('auth.admin')}:</strong> aipharmproject@gmail.com / Admin123!
-                    </p>
-                    <p>
-                      <strong>{t('auth.customers')}:</strong>{' '}
-                      <span className="block sm:inline">
-                        maria.ivanova@example.com / Customer123!
-                      </span>
-                      <br className="hidden sm:block" />
-                      <span className="block sm:inline">
-                        georgi.petrov@example.com / Customer456!
-                      </span>
-                      <br className="hidden sm:block" />
-                      <span className="block sm:inline">
-                        iva.stoyanova@example.com / Customer789!
-                      </span>
-                    </p>
-                    <p className="text-xs text-blue-600">
-                      Two-factor verification codes are emailed from{' '}
-                      <strong>aipharmproject@gmail.com</strong>. Enable the optional pickup folder
-                      (<code>Email:UsePickupDirectory = true</code>) if you want copies saved under{' '}
-                      <code>App_Data/Emails</code>; otherwise check the recipient inbox for the code.
-                    </p>
-                  </div>
-                </div>
-
                 <div className="mt-6 text-center">
                   <p className="text-gray-600">
                     {t('auth.noAccount')}{' '}

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -93,7 +93,6 @@ const HomePage: React.FC<HomePageProps> = ({
               <p className="text-sm font-semibold text-emerald-700 uppercase tracking-wide">
                 {t('home.dateTime.title')}
               </p>
-              <p className="text-sm text-emerald-600">{t('home.dateTime.autoUpdate')}</p>
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 w-full sm:w-auto text-emerald-900">
               <div>

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import HeroSection from '../HeroSection';
@@ -29,6 +29,33 @@ const HomePage: React.FC<HomePageProps> = ({
 }) => {
   const { t, language } = useLanguage();
   const navigate = useNavigate();
+  const [currentDateTime, setCurrentDateTime] = useState(() => new Date());
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      setCurrentDateTime(new Date());
+    }, 1000);
+
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  const locale = language === 'bg' ? 'bg-BG' : 'en-GB';
+
+  const formattedDate = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        dateStyle: 'full',
+      }).format(currentDateTime),
+    [currentDateTime, locale]
+  );
+
+  const formattedTime = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        timeStyle: 'medium',
+      }).format(currentDateTime),
+    [currentDateTime, locale]
+  );
 
   const selectedCategoryEntity = selectedCategory
     ? categories.find((category) => category.id === selectedCategory)
@@ -60,6 +87,31 @@ const HomePage: React.FC<HomePageProps> = ({
       {showHero && <HeroSection />}
 
       <main className="container mx-auto px-4 py-8 bg-white min-h-screen">
+        <section className="mb-8">
+          <div className="bg-emerald-50 border border-emerald-100 rounded-2xl p-5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div>
+              <p className="text-sm font-semibold text-emerald-700 uppercase tracking-wide">
+                {t('home.dateTime.title')}
+              </p>
+              <p className="text-sm text-emerald-600">{t('home.dateTime.autoUpdate')}</p>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 w-full sm:w-auto text-emerald-900">
+              <div>
+                <p className="text-xs font-medium uppercase text-emerald-700 tracking-wide">
+                  {t('home.dateTime.localDate')}
+                </p>
+                <p className="text-lg font-semibold">{formattedDate}</p>
+              </div>
+              <div>
+                <p className="text-xs font-medium uppercase text-emerald-700 tracking-wide">
+                  {t('home.dateTime.localTime')}
+                </p>
+                <p className="text-lg font-semibold">{formattedTime}</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
         {showPreview ? (
           <>
             <section className="mb-12">

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -47,7 +47,6 @@ const translations = {
     'home.dateTime.title': 'Текуща дата и час',
     'home.dateTime.localDate': 'Дата',
     'home.dateTime.localTime': 'Час',
-    'home.dateTime.autoUpdate': 'Актуализира се автоматично',
 
     // Categories
     'categories.title': 'Категории',
@@ -410,7 +409,6 @@ const translations = {
     'home.dateTime.title': 'Current date & time',
     'home.dateTime.localDate': 'Date',
     'home.dateTime.localTime': 'Time',
-    'home.dateTime.autoUpdate': 'Updates automatically',
 
     // Categories
     'categories.title': 'Categories',

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -43,6 +43,12 @@ const translations = {
     'hero.productsInStock': 'Продукта в наличност',
     'hero.professionalCare': 'Професионална грижа',
 
+    // Home Page
+    'home.dateTime.title': 'Текуща дата и час',
+    'home.dateTime.localDate': 'Дата',
+    'home.dateTime.localTime': 'Час',
+    'home.dateTime.autoUpdate': 'Актуализира се автоматично',
+
     // Categories
     'categories.title': 'Категории',
     'categories.subtitle': 'Разгледайте нашите основни категории и открийте подходящите продукти.',
@@ -133,7 +139,6 @@ const translations = {
     'auth.haveAccount': 'Вече имате акаунт?',
     'auth.loginHere': 'Влезте тук',
     'auth.registerHere': 'Регистрирайте се',
-    'auth.demoAccounts': 'Стандартен акаунт:',
     'auth.admin': 'Админ',
     'auth.customers': 'Клиенти',
     'auth.user': 'Потребител',
@@ -401,6 +406,12 @@ const translations = {
     'hero.productsInStock': 'Products in Stock',
     'hero.professionalCare': 'Professional Care',
 
+    // Home Page
+    'home.dateTime.title': 'Current date & time',
+    'home.dateTime.localDate': 'Date',
+    'home.dateTime.localTime': 'Time',
+    'home.dateTime.autoUpdate': 'Updates automatically',
+
     // Categories
     'categories.title': 'Categories',
     'categories.subtitle': 'Explore our main categories and find the right treatments.',
@@ -491,7 +502,6 @@ const translations = {
     'auth.haveAccount': 'Already have an account?',
     'auth.loginHere': 'Sign in here',
     'auth.registerHere': 'Register here',
-    'auth.demoAccounts': 'Default Account:',
     'auth.admin': 'Admin',
     'auth.customers': 'Customers',
     'auth.user': 'User',


### PR DESCRIPTION
## Summary
- remove the demo account hints from the login modal
- show the current date and time on the home page with automatic updates and localization
- add Bulgarian and English translations for the new home page copy

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3abdc18988331b7fe4740375bdc35