### PR TITLE
Refine catalog layouts for categories and products pages

### DIFF
--- a/src/components/pages/CategoriesPage.tsx
+++ b/src/components/pages/CategoriesPage.tsx
@@ -36,62 +36,80 @@ const CategoriesPage: React.FC<CategoriesPageProps> = ({ categories, products, o
   };
 
   return (
-    <div className="bg-gray-50 py-12">
-      <div className="container mx-auto px-4 space-y-12">
-        <section className="bg-white rounded-3xl shadow-sm border border-gray-100 p-8 lg:p-12">
-          <div className="max-w-3xl space-y-4">
-            <h1 className="text-4xl font-bold text-gray-900">{t('categories.title')}</h1>
-            <p className="text-lg text-gray-600 leading-relaxed">{t('categories.subtitle')}</p>
+    <div className="bg-gray-50 py-10">
+      <div className="container mx-auto px-4 space-y-8">
+        <section className="bg-white rounded-2xl border border-gray-100 shadow-sm p-6 lg:p-8 space-y-6">
+          <div className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
+            <div className="space-y-2 max-w-2xl">
+              <span className="text-sm font-semibold uppercase tracking-wide text-emerald-600">
+                {t('categories.title')}
+              </span>
+              <h1 className="text-3xl font-bold text-gray-900 lg:text-4xl">{t('products.catalogTitle')}</h1>
+              <p className="text-base text-gray-600 leading-relaxed">{t('categories.subtitle')}</p>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="inline-flex items-center gap-2 rounded-xl bg-emerald-50 px-4 py-2 text-sm font-semibold text-emerald-700">
+                <span className="h-2 w-2 rounded-full bg-emerald-500" aria-hidden />
+                {categories.length} {t('categories.title').toLowerCase()}
+              </span>
+              <span className="inline-flex items-center gap-2 rounded-xl bg-sky-50 px-4 py-2 text-sm font-semibold text-sky-700">
+                <span className="h-2 w-2 rounded-full bg-sky-500" aria-hidden />
+                {products.length} {t('products.products')}
+              </span>
+            </div>
           </div>
 
-          <div className="mt-8 flex flex-wrap items-center gap-4">
-            <span className="inline-flex items-center px-4 py-2 rounded-full bg-emerald-50 text-emerald-700 font-semibold">
-              {categories.length} {t('categories.title').toLowerCase()}
-            </span>
-            <span className="inline-flex items-center px-4 py-2 rounded-full bg-sky-50 text-sky-700 font-semibold">
-              {products.length} {t('products.products')}
-            </span>
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={handleViewAllProducts}
+              className="inline-flex items-center rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm font-semibold text-emerald-700 transition-colors hover:border-emerald-300 hover:bg-emerald-100"
+            >
+              {t('products.viewAll')}
+            </button>
+            <span className="text-sm text-gray-500">{t('products.categoryOverviewDescription')}</span>
           </div>
         </section>
 
-        <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          {categorySummaries.map((category) => {
-            const IconComponent = getCategoryIcon(category.icon);
+        <section className="bg-white rounded-2xl border border-gray-100 shadow-sm">
+          <div className="border-b border-gray-100 px-6 py-4">
+            <h2 className="text-lg font-semibold text-gray-900">{t('categories.title')}</h2>
+          </div>
+          <div className="p-4 sm:p-6">
+            <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-4">
+              {categorySummaries.map((category) => {
+                const IconComponent = getCategoryIcon(category.icon);
 
-            return (
-              <button
-                key={category.id}
-                type="button"
-                onClick={() => handleCategoryClick(category.id)}
-                className="text-left bg-white border border-gray-200 hover:border-emerald-300 hover:shadow-lg transition-all duration-300 rounded-2xl p-6 group"
-              >
-                <div className="flex items-center justify-between mb-4">
-                  <div className="w-12 h-12 rounded-xl bg-emerald-50 text-emerald-600 flex items-center justify-center group-hover:bg-emerald-100">
-                    <IconComponent className="w-6 h-6" />
-                  </div>
-                  <span className="text-sm font-semibold text-emerald-600">
-                    {category.count} {t('products.products')}
-                  </span>
-                </div>
-                <h3 className="text-xl font-semibold text-gray-900 mb-2">{category.translatedName}</h3>
-                <p className="text-sm text-gray-500 leading-relaxed mb-4">{category.description}</p>
-                <span className="inline-flex items-center text-sm font-semibold text-emerald-600 group-hover:text-emerald-700">
-                  {t('categories.viewProducts')}
-                  <ArrowRightCircle className="w-4 h-4 ml-2 transition-transform duration-300 group-hover:translate-x-1" />
-                </span>
-              </button>
-            );
-          })}
-        </section>
-
-        <section className="text-center">
-          <button
-            type="button"
-            onClick={handleViewAllProducts}
-            className="inline-flex items-center justify-center px-6 py-3 rounded-full bg-emerald-600 text-white font-semibold hover:bg-emerald-700 transition-colors"
-          >
-            {t('products.viewAll')}
-          </button>
+                return (
+                  <button
+                    key={category.id}
+                    type="button"
+                    onClick={() => handleCategoryClick(category.id)}
+                    className="group h-full rounded-xl border border-gray-200 bg-white p-4 text-left transition-all duration-200 hover:border-emerald-300 hover:shadow-md"
+                  >
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-3">
+                        <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-emerald-50 text-emerald-600 transition-colors duration-200 group-hover:bg-emerald-100">
+                          <IconComponent className="h-5 w-5" />
+                        </span>
+                        <h3 className="text-base font-semibold text-gray-900">{category.translatedName}</h3>
+                      </div>
+                      <span className="text-xs font-semibold uppercase tracking-wide text-emerald-600">
+                        {category.count} {t('products.products')}
+                      </span>
+                    </div>
+                    <p className="mt-3 text-xs text-gray-500 leading-relaxed">
+                      {category.description}
+                    </p>
+                    <span className="mt-4 inline-flex items-center text-xs font-semibold text-emerald-600 transition-transform duration-200 group-hover:translate-x-1">
+                      {t('categories.viewProducts')}
+                      <ArrowRightCircle className="ml-2 h-4 w-4" />
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
         </section>
       </div>
     </div>

--- a/src/components/pages/ProductsPage.tsx
+++ b/src/components/pages/ProductsPage.tsx
@@ -50,20 +50,42 @@ const ProductsPage: React.FC<ProductsPageProps> = ({
     : t('products.allProducts');
 
   return (
-    <div className="bg-gray-50 py-12">
-      <div className="container mx-auto px-4 space-y-10">
-        <section className="bg-white rounded-3xl shadow-sm border border-gray-100 p-8 lg:p-12">
-          <div className="max-w-3xl">
-            <h1 className="text-4xl font-bold text-gray-900 mb-4">{t('products.catalogTitle')}</h1>
-            <p className="text-lg text-gray-600 leading-relaxed">{t('products.catalogDescription')}</p>
+    <div className="bg-gray-50 py-10">
+      <div className="container mx-auto px-4 space-y-8">
+        <section className="space-y-6 rounded-2xl border border-gray-100 bg-white p-6 shadow-sm lg:p-8">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+            <div className="max-w-2xl space-y-3">
+              <span className="text-sm font-semibold uppercase tracking-wide text-emerald-600">
+                {t('products.catalogTitle')}
+              </span>
+              <h1 className="text-3xl font-bold text-gray-900 lg:text-4xl">{t('products.catalogDescription')}</h1>
+              <p className="text-base text-gray-600">{t('products.categoryOverviewDescription')}</p>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <div className="rounded-xl border border-emerald-100 bg-emerald-50 px-4 py-3 text-sm">
+                <p className="font-semibold text-emerald-700">{t('products.totalProductsLabel')}</p>
+                <p className="text-2xl font-bold text-emerald-800">{allProducts.length}</p>
+              </div>
+              <div className="rounded-xl border border-sky-100 bg-sky-50 px-4 py-3 text-sm">
+                <p className="font-semibold text-sky-700">{t('products.category')}</p>
+                <p className="text-2xl font-bold text-sky-800">{categories.length}</p>
+              </div>
+            </div>
           </div>
 
-          <div className="mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-            <div className="bg-emerald-50 border border-emerald-100 rounded-2xl p-6">
-              <p className="text-sm font-semibold text-emerald-700 mb-1">{t('products.totalProductsLabel')}</p>
-              <p className="text-3xl font-bold text-emerald-800">{allProducts.length}</p>
-              <p className="text-sm text-emerald-700 mt-2">{t('products.categoryOverviewDescription')}</p>
-            </div>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4 2xl:grid-cols-5">
+            <button
+              type="button"
+              onClick={() => onCategoryChange(null)}
+              className={`flex h-full flex-col justify-center rounded-xl border p-4 text-left text-emerald-700 transition-all duration-200 ${
+                selectedCategory === null
+                  ? 'border-emerald-300 bg-emerald-50 shadow-sm'
+                  : 'border-emerald-200 bg-emerald-50 hover:border-emerald-300 hover:bg-emerald-100'
+              }`}
+            >
+              <span className="text-sm font-semibold">{t('products.viewAll')}</span>
+              <span className="mt-1 text-xs text-emerald-700">{t('products.categoryOverview')}</span>
+            </button>
 
             {categorySummaries.map((category) => {
               const IconComponent = getCategoryIcon(category.icon);
@@ -74,34 +96,30 @@ const ProductsPage: React.FC<ProductsPageProps> = ({
                   key={category.id}
                   type="button"
                   onClick={() => onCategoryChange(category.id)}
-                  className={`text-left border rounded-2xl p-6 group transition-all duration-200 ${
+                  className={`group flex h-full flex-col justify-between rounded-xl border p-4 text-left transition-all duration-200 ${
                     isSelected
-                      ? 'bg-emerald-50 border-emerald-200 shadow-md'
-                      : 'bg-white border-gray-200 hover:border-emerald-300 hover:shadow-md'
+                      ? 'border-emerald-300 bg-emerald-50 shadow-sm'
+                      : 'border-gray-200 bg-white hover:border-emerald-300 hover:shadow-md'
                   }`}
                 >
-                  <div className="flex items-center justify-between mb-4">
-                    <div
-                      className={`w-12 h-12 rounded-xl flex items-center justify-center ${
-                        isSelected
-                          ? 'bg-emerald-500 text-white'
-                          : 'bg-emerald-50 text-emerald-600 group-hover:bg-emerald-100'
-                      }`}
-                    >
-                      <IconComponent className="w-6 h-6" />
-                    </div>
+                  <div className="flex items-center justify-between gap-3">
                     <span
-                      className={`text-sm font-semibold ${
-                        isSelected ? 'text-emerald-700' : 'text-emerald-600'
+                      className={`flex h-10 w-10 items-center justify-center rounded-lg text-emerald-600 transition-colors duration-200 ${
+                        isSelected ? 'bg-emerald-500 text-white' : 'bg-emerald-50 group-hover:bg-emerald-100'
                       }`}
                     >
+                      <IconComponent className="h-5 w-5" />
+                    </span>
+                    <span className="text-xs font-semibold uppercase tracking-wide text-emerald-600">
                       {category.count} {t('products.products')}
                     </span>
                   </div>
-                  <h3 className="text-lg font-semibold text-gray-900 mb-2">{category.translatedName}</h3>
-                  <p className="text-sm text-gray-500 leading-relaxed">
-                    {t('products.inCategory')} {category.translatedName}
-                  </p>
+                  <div className="mt-4 space-y-2">
+                    <h3 className="text-base font-semibold text-gray-900">{category.translatedName}</h3>
+                    <p className="text-xs text-gray-500">
+                      {t('products.inCategory')} {category.translatedName}
+                    </p>
+                  </div>
                 </button>
               );
             })}


### PR DESCRIPTION
## Summary
- tighten the categories landing layout with compact stats, inline "view all" action, and a denser category grid
- restructure the products catalog filters into a lighter grid with a dedicated reset tile and slimmer cards
- refresh supporting styles to reduce padding and keep more content above the fold on large screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4298851d88331ad70341ac5259eb6