### PR TITLE
Disable 2FA requirement for staff accounts

### DIFF
--- a/AIPharm.Backend/AIPharm.Web/Controllers/AuthController.cs
+++ b/AIPharm.Backend/AIPharm.Web/Controllers/AuthController.cs
@@ -425,7 +425,7 @@ namespace AIPharm.Web.Controllers
             user.TwoFactorLoginTokenExpiry.HasValue;
 
         private static bool RequiresTwoFactor(User user) =>
-            user.TwoFactorEnabled && !user.IsAdmin;
+            user.TwoFactorEnabled && !user.IsAdmin && !user.IsStaff;
 
         private async Task<bool> TrySendRegistrationEmailAsync(User user, CancellationToken cancellationToken)
         {

--- a/docs/two-factor-email.md
+++ b/docs/two-factor-email.md
@@ -1,6 +1,6 @@
 # Email-based Two-Factor Authentication
 
-The backend now enforces email-based two-factor authentication (2FA) for every user account. After a user enters valid credentials, a short-lived verification code is sent to the account's email address. The login flow completes only after the code is confirmed.
+The backend now enforces email-based two-factor authentication (2FA) for every customer account. After a user enters valid credentials, a short-lived verification code is sent to the account's email address. The login flow completes only after the code is confirmed. Administrative users and staff accounts are excluded from the 2FA requirement so they can access internal tooling without an extra verification step.
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- skip two-factor checks for staff members in the authentication controller
- document that administrative and staff accounts are exempt from the email 2FA flow

## Testing
- ⚠️ `dotnet test` *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daca2c58a08331ac8ced1d89691d24