### PR TITLE
Enable scrolling within product card details

### DIFF
--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -156,7 +156,7 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, onProductClick }) =>
       </div>
 
       {/* Content */}
-      <div className="flex flex-1 flex-col p-4">
+      <div className="flex flex-1 min-h-0 flex-col p-4">
         {/* Title */}
         <button
           type="button"
@@ -194,8 +194,8 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, onProductClick }) =>
           )}
         </div>
 
-        <div className="flex-1 overflow-hidden">
-          <div className="flex h-full flex-col gap-3 overflow-y-auto pr-1 text-sm text-gray-600">
+        <div className="flex-1 overflow-hidden min-h-0">
+          <div className="flex h-full min-h-0 flex-col gap-3 overflow-y-auto pr-1 text-sm text-gray-600">
             <div className="space-y-1">
               {getActiveIngredient() && (
                 <p>


### PR DESCRIPTION
## Summary
- ensure the product card content area can shrink within the card
- allow overflowing product information and promotion details to scroll within the card

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dace8ccc448331bacb95b1a159903b