### PR TITLE
Move date and time display to header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import {
   Search,
@@ -42,7 +42,7 @@ const Header: React.FC<HeaderProps> = ({
 }) => {
   const { state, dispatch } = useCart();
   const { user, isAuthenticated, isAdmin, isStaff, logout } = useAuth();
-  const { t } = useLanguage();
+  const { t, language } = useLanguage();
   const location = useLocation();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [showLoginModal, setShowLoginModal] = useState(false);
@@ -50,6 +50,7 @@ const Header: React.FC<HeaderProps> = ({
   const [showUserMenu, setShowUserMenu] = useState(false);
   const [showProfileModal, setShowProfileModal] = useState(false);
   const [showOrdersModal, setShowOrdersModal] = useState(false);
+  const [currentDateTime, setCurrentDateTime] = useState(() => new Date());
 
   const canAccessAdmin = isAdmin || isStaff;
 
@@ -66,6 +67,36 @@ const Header: React.FC<HeaderProps> = ({
       window.removeEventListener('aiPharm:openLoginModal', handleOpenLoginModal);
     };
   }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const intervalId = window.setInterval(() => {
+      setCurrentDateTime(new Date());
+    }, 1000);
+
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  const locale = language === 'bg' ? 'bg-BG' : 'en-GB';
+
+  const formattedDate = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        dateStyle: 'full',
+      }).format(currentDateTime),
+    [currentDateTime, locale]
+  );
+
+  const formattedTime = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        timeStyle: 'medium',
+      }).format(currentDateTime),
+    [currentDateTime, locale]
+  );
 
   const handleLogout = async () => {
     await logout();
@@ -126,6 +157,11 @@ const Header: React.FC<HeaderProps> = ({
           </div>
           <div className="flex items-center space-x-6">
             <LanguageSwitcher />
+            <div className="flex items-center space-x-2 text-emerald-700 font-medium">
+              <span>{formattedDate}</span>
+              <span className="text-gray-300">•</span>
+              <span>{formattedTime}</span>
+            </div>
             {isAuthenticated && canAccessAdmin && (
               <Link
                 to="/admin"

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import HeroSection from '../HeroSection';
@@ -29,34 +29,6 @@ const HomePage: React.FC<HomePageProps> = ({
 }) => {
   const { t, language } = useLanguage();
   const navigate = useNavigate();
-  const [currentDateTime, setCurrentDateTime] = useState(() => new Date());
-
-  useEffect(() => {
-    const intervalId = window.setInterval(() => {
-      setCurrentDateTime(new Date());
-    }, 1000);
-
-    return () => window.clearInterval(intervalId);
-  }, []);
-
-  const locale = language === 'bg' ? 'bg-BG' : 'en-GB';
-
-  const formattedDate = useMemo(
-    () =>
-      new Intl.DateTimeFormat(locale, {
-        dateStyle: 'full',
-      }).format(currentDateTime),
-    [currentDateTime, locale]
-  );
-
-  const formattedTime = useMemo(
-    () =>
-      new Intl.DateTimeFormat(locale, {
-        timeStyle: 'medium',
-      }).format(currentDateTime),
-    [currentDateTime, locale]
-  );
-
   const promotedProducts = useMemo(
     () => allProducts.filter((product) => Boolean(product.promotion)),
     [allProducts]
@@ -97,30 +69,6 @@ const HomePage: React.FC<HomePageProps> = ({
       {showHero && <HeroSection />}
 
       <main className="container mx-auto px-4 py-8 bg-white min-h-screen">
-        <section className="mb-8">
-          <div className="bg-emerald-50 border border-emerald-100 rounded-2xl p-5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-            <div>
-              <p className="text-sm font-semibold text-emerald-700 uppercase tracking-wide">
-                {t('home.dateTime.title')}
-              </p>
-            </div>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 w-full sm:w-auto text-emerald-900">
-              <div>
-                <p className="text-xs font-medium uppercase text-emerald-700 tracking-wide">
-                  {t('home.dateTime.localDate')}
-                </p>
-                <p className="text-lg font-semibold">{formattedDate}</p>
-              </div>
-              <div>
-                <p className="text-xs font-medium uppercase text-emerald-700 tracking-wide">
-                  {t('home.dateTime.localTime')}
-                </p>
-                <p className="text-lg font-semibold">{formattedTime}</p>
-              </div>
-            </div>
-          </div>
-        </section>
-
         {showPreview ? (
           <>
             <section className="mb-12">


### PR DESCRIPTION
## Summary
- move the live date and time indicator from the home page banner into the header top bar
- add localized date and time formatting logic to the header and remove the redundant section from the home page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dacf649dbc8331b13a3200fef860d9