### PR TITLE
Move prescription services toggle to admin panel

### DIFF
--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -28,6 +28,7 @@ import { useAuth } from '../../context/AuthContext';
 import { useLanguage } from '../../context/LanguageContext';
 import { useNews } from '../../context/NewsContext';
 import { useProductCatalog } from '../../context/ProductCatalogContext';
+import { useFeatureToggles } from '../../context/FeatureToggleContext';
 import type { NewsArticle, OrderStatus, PaymentMethod, Product, ProductPromotion } from '../../types';
 import { generateNewsImage } from '../../utils/imageGenerator';
 
@@ -316,8 +317,12 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
     updateProduct,
     deleteProduct: removeProductFromCatalog,
   } = useProductCatalog();
+  const { prescriptionFeaturesEnabled, setPrescriptionFeaturesEnabled } = useFeatureToggles();
   const isModal = variant === 'modal';
   const canAccessAdmin = isAdmin || isStaffUser;
+  const handlePrescriptionFeatureToggle = () => {
+    setPrescriptionFeaturesEnabled(!prescriptionFeaturesEnabled);
+  };
   const isPanelOpen = isModal ? isOpen : true;
   const canManageOrders = canAccessAdmin;
   const canManageUsers = isAdmin;
@@ -1512,7 +1517,51 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
           </div>
         </div>
 
-        <div className="p-6">
+        <div className="space-y-6 p-6">
+          {activeView === 'permissions' && (
+            <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-4">
+              <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <span className="text-xs font-semibold uppercase tracking-wide text-emerald-700">
+                    {t('admin.features.sectionTitle')}
+                  </span>
+                  <p className="mt-2 text-sm font-semibold text-emerald-900">
+                    {t('admin.features.prescriptionTitle')}
+                  </p>
+                  <p className="mt-1 text-sm text-emerald-900/80">
+                    {t('admin.features.prescriptionDescription')}
+                  </p>
+                  <p className="mt-2 text-xs font-medium text-emerald-700">
+                    {prescriptionFeaturesEnabled
+                      ? t('admin.features.prescriptionStatusEnabled')
+                      : t('admin.features.prescriptionStatusDisabled')}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={prescriptionFeaturesEnabled}
+                  onClick={handlePrescriptionFeatureToggle}
+                  className={`relative inline-flex h-10 w-20 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 ${
+                    prescriptionFeaturesEnabled ? 'bg-emerald-500' : 'bg-emerald-200'
+                  }`}
+                >
+                  <span className="sr-only">{t('admin.features.prescriptionToggle')}</span>
+                  <span
+                    aria-hidden="true"
+                    className={`pointer-events-none inline-block h-8 w-8 transform rounded-full bg-white shadow ring-0 transition duration-200 ${
+                      prescriptionFeaturesEnabled ? 'translate-x-10' : 'translate-x-0'
+                    }`}
+                  />
+                  <span className="absolute inset-0 flex items-center justify-center text-xs font-semibold uppercase text-white">
+                    {prescriptionFeaturesEnabled
+                      ? t('admin.features.prescriptionEnabled')
+                      : t('admin.features.prescriptionDisabled')}
+                  </span>
+                </button>
+              </div>
+            </div>
+          )}
           {selectedUser && editData ? (
             <form onSubmit={handleSave} className="space-y-6">
               <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">

--- a/src/components/profile/ProfileSettingsModal.tsx
+++ b/src/components/profile/ProfileSettingsModal.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { X, Mail, User, Phone, MapPin, Shield, Settings } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import { useLanguage } from '../../context/LanguageContext';
-import { useFeatureToggles } from '../../context/FeatureToggleContext';
 
 interface ProfileSettingsModalProps {
   isOpen: boolean;
@@ -13,7 +12,6 @@ type MessageState = { type: 'success' | 'error'; text: string } | null;
 
 const ProfileSettingsModal: React.FC<ProfileSettingsModalProps> = ({ isOpen, onClose }) => {
   const { user, updateProfile, isAdmin, isStaff } = useAuth();
-  const { prescriptionFeaturesEnabled, setPrescriptionFeaturesEnabled } = useFeatureToggles();
   const { t } = useLanguage();
   const [formData, setFormData] = useState({
     fullName: '',
@@ -73,10 +71,6 @@ const ProfileSettingsModal: React.FC<ProfileSettingsModalProps> = ({ isOpen, onC
       (formData.address ?? '') !== (user.address ?? '')
     );
   }, [formData, user]);
-
-  const handlePrescriptionToggle = () => {
-    setPrescriptionFeaturesEnabled(!prescriptionFeaturesEnabled);
-  };
 
   if (!isOpen) {
     return null;
@@ -196,48 +190,6 @@ const ProfileSettingsModal: React.FC<ProfileSettingsModalProps> = ({ isOpen, onC
                     }`}
                   >
                     {message.text}
-                  </div>
-                )}
-
-                {isAdmin && (
-                  <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-4">
-                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                      <div>
-                        <p className="text-sm font-semibold text-amber-800 uppercase tracking-wide">
-                          {t('profile.prescriptionFeaturesTitle')}
-                        </p>
-                        <p className="mt-1 text-sm text-amber-900/80">
-                          {t('profile.prescriptionFeaturesDescription')}
-                        </p>
-                        <p className="mt-2 text-xs font-medium text-amber-700">
-                          {prescriptionFeaturesEnabled
-                            ? t('profile.prescriptionFeaturesStatusEnabled')
-                            : t('profile.prescriptionFeaturesStatusDisabled')}
-                        </p>
-                      </div>
-                      <button
-                        type="button"
-                        role="switch"
-                        aria-checked={prescriptionFeaturesEnabled}
-                        onClick={handlePrescriptionToggle}
-                        className={`relative inline-flex h-10 w-20 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 ${
-                          prescriptionFeaturesEnabled ? 'bg-emerald-500' : 'bg-amber-200'
-                        }`}
-                      >
-                        <span className="sr-only">{t('profile.prescriptionFeaturesToggle')}</span>
-                        <span
-                          aria-hidden="true"
-                          className={`pointer-events-none inline-block h-8 w-8 transform rounded-full bg-white shadow ring-0 transition duration-200 ${
-                            prescriptionFeaturesEnabled ? 'translate-x-10' : 'translate-x-0'
-                          }`}
-                        />
-                        <span className="absolute inset-0 flex items-center justify-center text-xs font-semibold uppercase text-white">
-                          {prescriptionFeaturesEnabled
-                            ? t('profile.prescriptionFeaturesEnabled')
-                            : t('profile.prescriptionFeaturesDisabled')}
-                        </span>
-                      </button>
-                    </div>
                   </div>
                 )}
 

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -278,16 +278,6 @@ const translations = {
     'profile.readonlyEmail': 'Имейл адресът не може да бъде променян.',
     'profile.adminBadge': 'Администратор',
     'profile.staffBadge': 'Служител',
-    'profile.prescriptionFeaturesTitle': 'Рецептурни услуги',
-    'profile.prescriptionFeaturesDescription':
-      'Контролирайте достъпа до продукти с рецепта и подаването на е-рецепти.',
-    'profile.prescriptionFeaturesStatusEnabled':
-      'Потребителите виждат продуктите с рецепта и могат да завършват е-рецепти.',
-    'profile.prescriptionFeaturesStatusDisabled':
-      'Продуктите с рецепта и е-рецепциите са скрити за всички потребители.',
-    'profile.prescriptionFeaturesToggle': 'Управление на рецептурните услуги',
-    'profile.prescriptionFeaturesEnabled': 'Вкл.',
-    'profile.prescriptionFeaturesDisabled': 'Изкл.',
     'profile.fullName': 'Пълно име',
     'profile.fullNamePlaceholder': 'Иван Иванов',
     'profile.phoneNumber': 'Телефон',
@@ -335,6 +325,17 @@ const translations = {
     'admin.panel.tabs.orders': 'Поръчки',
     'admin.panel.tabs.products': 'Каталог',
     'admin.panel.tabs.news': 'Новини',
+    'admin.features.sectionTitle': 'Функции на платформата',
+    'admin.features.prescriptionTitle': 'Рецептурни услуги',
+    'admin.features.prescriptionDescription':
+      'Контролирайте достъпа до продукти с рецепта и подаването на е-рецепти.',
+    'admin.features.prescriptionStatusEnabled':
+      'Потребителите виждат продуктите с рецепта и могат да завършват е-рецепти.',
+    'admin.features.prescriptionStatusDisabled':
+      'Продуктите с рецепта и е-рецепциите са скрити за всички потребители.',
+    'admin.features.prescriptionToggle': 'Управление на рецептурните услуги',
+    'admin.features.prescriptionEnabled': 'Вкл.',
+    'admin.features.prescriptionDisabled': 'Изкл.',
     'admin.users.searchLabel': 'Търсене на потребители',
     'admin.users.searchPlaceholder': 'Име, имейл или телефон...',
     'admin.users.errors.noSession': 'Не е намерен валиден админ токен. Влезте отново.',
@@ -974,16 +975,6 @@ const translations = {
     'profile.readonlyEmail': 'The email address cannot be changed.',
     'profile.adminBadge': 'Administrator',
     'profile.staffBadge': 'Staff member',
-    'profile.prescriptionFeaturesTitle': 'Prescription services',
-    'profile.prescriptionFeaturesDescription':
-      'Control the availability of prescription-only products and e-prescriptions.',
-    'profile.prescriptionFeaturesStatusEnabled':
-      'Customers can see prescription medicines and submit e-prescriptions.',
-    'profile.prescriptionFeaturesStatusDisabled':
-      'Prescription medicines and e-prescriptions are hidden for all customers.',
-    'profile.prescriptionFeaturesToggle': 'Toggle prescription services',
-    'profile.prescriptionFeaturesEnabled': 'On',
-    'profile.prescriptionFeaturesDisabled': 'Off',
     'profile.fullName': 'Full name',
     'profile.fullNamePlaceholder': 'John Doe',
     'profile.phoneNumber': 'Phone number',
@@ -1031,6 +1022,17 @@ const translations = {
     'admin.panel.tabs.orders': 'Orders',
     'admin.panel.tabs.products': 'Catalog',
     'admin.panel.tabs.news': 'News',
+    'admin.features.sectionTitle': 'Platform features',
+    'admin.features.prescriptionTitle': 'Prescription services',
+    'admin.features.prescriptionDescription':
+      'Control the availability of prescription-only products and e-prescription submissions.',
+    'admin.features.prescriptionStatusEnabled':
+      'Customers can see prescription-only items and submit e-prescriptions.',
+    'admin.features.prescriptionStatusDisabled':
+      'Prescription-only products and e-prescriptions are hidden for all customers.',
+    'admin.features.prescriptionToggle': 'Manage prescription services',
+    'admin.features.prescriptionEnabled': 'On',
+    'admin.features.prescriptionDisabled': 'Off',
     'admin.users.searchLabel': 'Search users',
     'admin.users.searchPlaceholder': 'Name, email or phone...',
     'admin.users.errors.noSession': 'Missing admin session. Please sign in again.',


### PR DESCRIPTION
## Summary
- remove the prescription services toggle from the admin profile settings modal
- expose the prescription services feature toggle inside the admin permissions view with dedicated copy
- migrate the related translations under the admin namespace for both Bulgarian and English locales

## Testing
- npm run lint *(fails: existing `@typescript-eslint/no-empty-object-type` error in ProductCatalogContext)*

------
https://chatgpt.com/codex/tasks/task_e_68dad907eb508331b747d4de67f3c5d5