### PR TITLE
Add 0.1.0 version banner and refresh AI agent docs

### DIFF
--- a/Infrastructure.md
+++ b/Infrastructure.md
@@ -1,1 +1,19 @@
-﻿
+# Infrastructure Notes (v0.1.0)
+
+## Frontend
+- **Framework:** React 18 + TypeScript running on Vite.
+- **Styling:** Tailwind CSS with custom gradients and motion for hero/footer components.
+- **Caching:** No service worker or data caching layer is configured yet. All product and news reads go straight to the API.
+- **Version banner:** The footer renders the release number from `src/config/appVersion.ts` so deployments remain traceable.
+
+## Backend
+- **Tech stack:** .NET 8 Web API, Entity Framework Core, SQL Server 2022 container.
+- **Authentication:** JWT bearer tokens with seeded demo accounts.
+- **AI integration:** OpenAI client configured through `OpenAI__ApiKey` in environment variables or `appsettings.json`.
+
+## DevOps
+- **Containers:** `docker-compose.yml` orchestrates `frontend`, `backend`, and `database` services for local parity.
+- **CI/CD hooks:** Run `npm run build` for the frontend and `dotnet test` in the backend solution before deployment.
+- **Versioning policy:** Semantic versioning starting at **0.1.0**. Increment the patch number for fixes, minor number for feature batches, and major for breaking changes.
+
+Review [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) for cloud-specific instructions.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ AIPharm+ is a full digital-pharmacy demo that combines a .NET 8 Web API, a React
 data, and an AI chat assistant powered by OpenAI. The goal is to help you explore a realistic e-commerce experience that includes
 medical product browsing, ordering, and conversational support.
 
+> **Current version:** 0.1.0 (January 2025)
+
+### 0.1.0 release notes
+- Version banner added to the storefront footer so visitors always know which release is running.
+- Documentation refreshed with AI agent guidance and up-to-date setup instructions.
+- Verified that no client-side caching layer is active yet—see the new performance notes if you plan to add one.
+
 This README keeps the original project context while adding step-by-step setup guidance for newcomers. If you follow each section
 in order you will have the project running locally.
 
@@ -25,6 +32,11 @@ in order you will have the project running locally.
 | Tailwind CSS styling with responsive layouts | Entity Framework Core with SQL Server |
 | Dynamic product catalog, cart, and checkout flows | JWT authentication, email notifications, and background services |
 | Built-in AI chat widget for customer help | Swagger/OpenAPI docs, health checks, and seeded demo data |
+
+### Performance and caching
+- **Client-side caching:** Not yet implemented. Product and news data are fetched directly from the API on each visit, so consider integrating React Query, SWR, or a service worker cache for frequently accessed resources.
+- **Build-time optimization:** The Vite build already code-splits the React bundle. Host the compiled assets behind a CDN to take advantage of HTTP caching headers.
+- **Backend caching:** The .NET API queries SQL Server per request. Introduce Redis or in-memory caching for high-traffic endpoints when you move beyond demo scale.
 
 ### Architecture at a glance
 ```mermaid
@@ -68,6 +80,12 @@ graph TB
 ```
 
 </details>
+
+## AI agents & automation (AI агенти)
+- Learn how the AI chat assistant is wired into the backend, how it stores context, and how to extend it for customer-service automations in [`docs/AI-AGENTS.md`](docs/AI-AGENTS.md).
+- Документът включва **начални промптове** за стартиране на агент за разработка, примерни правила за безопасност и инструкции за наблюдение на разходите към OpenAI API.
+- Recommended starter prompt for development work: _"Act as the AIPharm+ development co-pilot. Before coding, confirm the active feature flag set, check the current version (0.1.0), and list impacted microservices. Provide a step-by-step plan before editing files."_  
+  Препоръчителен начален промпт (BG): _"Действай като AIPharm+ агент за разработка. Провери текущата версия (0.1.0), активните функционални флагове и зависимостите към бекенда, след което предложи план на български преди да правиш промени."_
 
 Use the sections below when you are ready to clone the repository and configure your environment.
 

--- a/docs/AI-AGENTS.md
+++ b/docs/AI-AGENTS.md
@@ -1,0 +1,28 @@
+# AI Agents Playbook
+
+## Overview
+AIPharm+ ships with an OpenAI-powered assistant that answers medical questions and guides users through the storefront. This document explains how the existing integration works and how to launch additional automation agents for development or support workflows.
+
+## Existing assistant
+- **Endpoint:** `AIPharm.Backend/AIPharm.Web` exposes the chat API that the React widget calls.
+- **Context:** The backend seeds medical products and uses them to ground the assistant answers.
+- **Rate limits:** All requests flow through your OpenAI API key. Monitor usage in the OpenAI dashboard and set soft limits to avoid unexpected costs.
+
+## Launching a development agent (Начален промпт)
+1. Confirm your local `.env` includes `OpenAI__ApiKey` so the backend can route messages.
+2. Use the following starter prompts when bootstrapping a development-focused agent:
+   - **English:** `Act as the AIPharm+ development co-pilot. Before writing code, list the affected UI routes, check the current release version (0.1.0), and outline a step-by-step plan with test coverage ideas.`
+   - **Български:** `Действай като AIPharm+ агент за разработка. Провери текущата версия (0.1.0), изброи засегнатите страници и предложи план за имплементация и тестове.`
+3. Always ask the agent to verify feature toggles via the `FeatureToggleContext` and to check the latest changelog.
+
+## Safety checklist
+- **PII handling:** Never store personal health information in prompts or logs. Redact customer details before forwarding requests to OpenAI.
+- **Medical disclaimer:** The assistant must remind users to consult a licensed physician for diagnosis or prescriptions.
+- **Audit trail:** Log the user ID, question, and model response in secure storage if you plan to use the chat in production.
+
+## Extending the ecosystem
+- Add queue workers that process pharmacy orders by calling the backend once the agent validates prescriptions.
+- Configure alerting (PagerDuty, email) when the agent encounters repeated API failures or exceeds cost thresholds.
+- Explore caching agent responses with Redis if you introduce FAQs or repeated troubleshooting steps.
+
+For deeper architectural context review [`docs/DEPLOYMENT.md`](DEPLOYMENT.md) and the main [README](../README.md) release notes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aipharm-plus",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aipharm-plus",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "framer-motion": "^10.16.16",
         "lucide-react": "^0.344.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aipharm-plus",
   "private": true,
-  "version": "1.0.0",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,6 +4,7 @@ import { Mail, Phone, MapPin, Facebook, Instagram, Stethoscope, Shield, Award, S
 import { useLanguage } from '../context/LanguageContext';
 import AIPharmLogo from './Logo';
 import { quickLinks } from '../data/navigation';
+import { APP_VERSION } from '../config/appVersion';
 
 const Footer: React.FC = () => {
   const { t } = useLanguage();
@@ -212,10 +213,15 @@ const Footer: React.FC = () => {
         </div>
 
         {/* Bottom section */}
-        <div className="border-t border-white/10 mt-12 pt-8 flex flex-col lg:flex-row items-center justify-between">
-          <p className="text-gray-400 text-sm mb-4 lg:mb-0">
-            {t('footer.copyright')}
-          </p>
+        <div className="border-t border-white/10 mt-12 pt-8 flex flex-col lg:flex-row items-center justify-between gap-4">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:space-x-4 text-center sm:text-left">
+            <p className="text-gray-400 text-sm">
+              {t('footer.version', { version: APP_VERSION })}
+            </p>
+            <p className="text-gray-400 text-sm">
+              {t('footer.copyright')}
+            </p>
+          </div>
           <div className="flex flex-wrap justify-center lg:justify-end space-x-6 text-sm text-gray-400">
             <button className="hover:text-white transition-colors duration-300 hover:underline">
               {t('footer.privacy')}

--- a/src/config/appVersion.ts
+++ b/src/config/appVersion.ts
@@ -1,0 +1,1 @@
+export const APP_VERSION = '0.1.0';

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -540,6 +540,7 @@ const translations = {
     // Footer
     'footer.title': 'AIPHARM+',
     'footer.description': 'Качествени лекарства с AI консултации и бърза доставка.',
+    'footer.version': 'Версия {version}',
     'footer.quickLinks': 'Бързи връзки',
     'footer.aboutUs': 'За нас',
     'footer.products': 'Продукти',
@@ -1249,6 +1250,7 @@ const translations = {
     // Footer
     'footer.title': 'AIPHARM+',
     'footer.description': 'Quality medicines with AI consultations and fast delivery.',
+    'footer.version': 'Version {version}',
     'footer.quickLinks': 'Quick Links',
     'footer.aboutUs': 'About Us',
     'footer.products': 'Products',


### PR DESCRIPTION
## Summary
- add an appVersion config constant and render v0.1.0 in the footer
- document the new release, caching status, and AI agent prompts across README and Infrastructure notes
- create an AI agent playbook with starter prompts and safety guidance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db5d374a2c83318e7f1744fe54d6b4