### PR TITLE
Expand admin catalog list height

### DIFF
--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -1926,7 +1926,7 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
               </div>
             </div>
 
-            <div className="relative max-h-[60vh] overflow-hidden rounded-2xl border border-slate-100 bg-slate-50">
+            <div className="relative max-h-[75vh] overflow-hidden rounded-2xl border border-slate-100 bg-slate-50 lg:max-h-[80vh]">
               {filteredCatalogProducts.length ? (
                 <div className="space-y-2 overflow-y-auto p-3">
                   {filteredCatalogProducts.map((product) => {


### PR DESCRIPTION
## Summary
- increase the maximum height of the admin catalog list to allow more products to be visible at once

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db690d78a08331bc35d30d8241f47b