### PR TITLE
Convert categories to GUID primary keys

### DIFF
--- a/AIPharm.Backend/AIPharm.Core.Tests/Controllers/ProductsControllerTests.cs
+++ b/AIPharm.Backend/AIPharm.Core.Tests/Controllers/ProductsControllerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using AIPharm.Core.DTOs;
 using AIPharm.Core.Interfaces;
 using AIPharm.Web.Controllers;
@@ -21,7 +22,7 @@ public class ProductsControllerTests
     [Fact]
     public async Task CreateProduct_WhenCategoryIsInvalid_ReturnsBadRequest()
     {
-        var dto = new CreateProductDto { CategoryId = 99 };
+        var dto = new CreateProductDto { CategoryId = Guid.NewGuid() };
 
         _productServiceMock
             .Setup(service => service.CreateProductAsync(It.IsAny<CreateProductDto>()))
@@ -36,7 +37,8 @@ public class ProductsControllerTests
     [Fact]
     public async Task CreateProduct_WhenSuccessful_ReturnsCreatedAtAction()
     {
-        var dto = new CreateProductDto { Name = "Painkiller", CategoryId = 1 };
+        var categoryId = Guid.NewGuid();
+        var dto = new CreateProductDto { Name = "Painkiller", CategoryId = categoryId };
         var product = new ProductDto { Id = 10, Name = dto.Name, CategoryId = dto.CategoryId };
 
         _productServiceMock
@@ -52,7 +54,7 @@ public class ProductsControllerTests
     [Fact]
     public async Task UpdateProduct_WhenCategoryIsInvalid_ReturnsBadRequest()
     {
-        var dto = new UpdateProductDto { CategoryId = 5 };
+        var dto = new UpdateProductDto { CategoryId = Guid.NewGuid() };
 
         _productServiceMock
             .Setup(service => service.UpdateProductAsync(It.IsAny<int>(), It.IsAny<UpdateProductDto>()))

--- a/AIPharm.Backend/AIPharm.Core.Tests/ProductServiceTests.cs
+++ b/AIPharm.Backend/AIPharm.Core.Tests/ProductServiceTests.cs
@@ -191,7 +191,7 @@ public class ProductServiceTests
         return configuration.CreateMapper();
     }
 
-    private sealed record SeedData(int AnalgesicsCategoryId, List<int> MatchingProductIds);
+    private sealed record SeedData(Guid AnalgesicsCategoryId, List<int> MatchingProductIds);
 
     private sealed class CommandCaptureInterceptor : DbCommandInterceptor
     {

--- a/AIPharm.Backend/AIPharm.Core.Tests/Services/ProductServiceTests.cs
+++ b/AIPharm.Backend/AIPharm.Core.Tests/Services/ProductServiceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using AutoMapper;
 using AIPharm.Core.DTOs;
 using AIPharm.Core.Interfaces;
@@ -31,17 +32,19 @@ public class ProductServiceTests
     [Fact]
     public async Task CreateProductAsync_WithValidCategory_ReturnsProductDto()
     {
+        var categoryId = Guid.NewGuid();
+
         var createDto = new CreateProductDto
         {
             Name = "Painkiller",
             Description = "Fast acting relief",
             Price = 19.99m,
             StockQuantity = 10,
-            CategoryId = 1,
+            CategoryId = categoryId,
             RequiresPrescription = false
         };
 
-        var category = new Category { Id = 1, Name = "Analgesics", Icon = "pill" };
+        var category = new Category { Id = categoryId, Name = "Analgesics", Icon = "pill" };
 
         _categoryRepositoryMock
             .Setup(repo => repo.GetByIdAsync(createDto.CategoryId))
@@ -67,12 +70,13 @@ public class ProductServiceTests
     [Fact]
     public async Task CreateProductAsync_WithInvalidCategory_ThrowsArgumentException()
     {
+        var categoryId = Guid.NewGuid();
         var createDto = new CreateProductDto
         {
             Name = "Painkiller",
             Price = 19.99m,
             StockQuantity = 10,
-            CategoryId = 99
+            CategoryId = categoryId
         };
 
         _categoryRepositoryMock
@@ -88,11 +92,14 @@ public class ProductServiceTests
     [Fact]
     public async Task UpdateProductAsync_WithValidCategory_ReturnsUpdatedProductDto()
     {
+        var originalCategoryId = Guid.NewGuid();
+        var updatedCategoryId = Guid.NewGuid();
+
         var existingProduct = new Product
         {
             Id = 5,
             Name = "Painkiller",
-            CategoryId = 1,
+            CategoryId = originalCategoryId,
             Price = 9.99m,
             StockQuantity = 5,
             CreatedAt = DateTime.UtcNow.AddDays(-1),
@@ -102,11 +109,11 @@ public class ProductServiceTests
         var updateDto = new UpdateProductDto
         {
             Name = "Painkiller Plus",
-            CategoryId = 2,
+            CategoryId = updatedCategoryId,
             Price = 14.99m
         };
 
-        var category = new Category { Id = 2, Name = "Supplements", Icon = "leaf" };
+        var category = new Category { Id = updatedCategoryId, Name = "Supplements", Icon = "leaf" };
 
         _productRepositoryMock
             .Setup(repo => repo.GetByIdAsync(existingProduct.Id))
@@ -132,16 +139,18 @@ public class ProductServiceTests
     [Fact]
     public async Task UpdateProductAsync_WithInvalidCategory_ThrowsArgumentException()
     {
+        var originalCategoryId = Guid.NewGuid();
+        var missingCategoryId = Guid.NewGuid();
         var existingProduct = new Product
         {
             Id = 5,
             Name = "Painkiller",
-            CategoryId = 1
+            CategoryId = originalCategoryId
         };
 
         var updateDto = new UpdateProductDto
         {
-            CategoryId = 99
+            CategoryId = missingCategoryId
         };
 
         _productRepositoryMock
@@ -168,6 +177,6 @@ public class ProductServiceTests
 
         await Assert.ThrowsAsync<KeyNotFoundException>(() => _productService.UpdateProductAsync(123, updateDto));
 
-        _categoryRepositoryMock.Verify(repo => repo.GetByIdAsync(It.IsAny<int>()), Times.Never);
+        _categoryRepositoryMock.Verify(repo => repo.GetByIdAsync(It.IsAny<Guid>()), Times.Never);
     }
 }

--- a/AIPharm.Backend/AIPharm.Core/DTOs/CategoryDto.cs
+++ b/AIPharm.Backend/AIPharm.Core/DTOs/CategoryDto.cs
@@ -1,8 +1,10 @@
+using System;
+
 namespace AIPharm.Core.DTOs
 {
     public class CategoryDto
     {
-        public int Id { get; set; }
+        public Guid Id { get; set; }
         public string Name { get; set; } = string.Empty;
         public string? Description { get; set; }
         public string Icon { get; set; } = string.Empty;

--- a/AIPharm.Backend/AIPharm.Core/DTOs/ProductDto.cs
+++ b/AIPharm.Backend/AIPharm.Core/DTOs/ProductDto.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace AIPharm.Core.DTOs
@@ -20,8 +21,7 @@ namespace AIPharm.Core.DTOs
         public int StockQuantity { get; set; }
         [StringLength(500, ErrorMessage = "ImageUrl cannot exceed 500 characters.")]
         public string? ImageUrl { get; set; }
-        [Range(1, int.MaxValue, ErrorMessage = "CategoryId must be a positive integer.")]
-        public int CategoryId { get; set; }
+        public Guid CategoryId { get; set; }
         public string? CategoryName { get; set; }
         public bool RequiresPrescription { get; set; }
         [StringLength(200, ErrorMessage = "ActiveIngredient cannot exceed 200 characters.")]
@@ -58,8 +58,8 @@ namespace AIPharm.Core.DTOs
         public int StockQuantity { get; set; }
         [StringLength(500, ErrorMessage = "ImageUrl cannot exceed 500 characters.")]
         public string? ImageUrl { get; set; }
-        [Range(1, int.MaxValue, ErrorMessage = "CategoryId must be a positive integer.")]
-        public int CategoryId { get; set; }
+        [Required(ErrorMessage = "CategoryId is required.")]
+        public Guid CategoryId { get; set; }
         public bool RequiresPrescription { get; set; }
         [StringLength(200, ErrorMessage = "ActiveIngredient cannot exceed 200 characters.")]
         public string? ActiveIngredient { get; set; }
@@ -91,8 +91,7 @@ namespace AIPharm.Core.DTOs
         public int? StockQuantity { get; set; }
         [StringLength(500, ErrorMessage = "ImageUrl cannot exceed 500 characters.")]
         public string? ImageUrl { get; set; }
-        [Range(1, int.MaxValue, ErrorMessage = "CategoryId must be a positive integer.")]
-        public int? CategoryId { get; set; }
+        public Guid? CategoryId { get; set; }
         public bool? RequiresPrescription { get; set; }
         [StringLength(200, ErrorMessage = "ActiveIngredient cannot exceed 200 characters.")]
         public string? ActiveIngredient { get; set; }
@@ -110,8 +109,7 @@ namespace AIPharm.Core.DTOs
 
     public class ProductFilterDto
     {
-        [Range(1, int.MaxValue, ErrorMessage = "CategoryId must be a positive integer.")]
-        public int? CategoryId { get; set; }
+        public Guid? CategoryId { get; set; }
         [Range(typeof(decimal), "0", "99999999.99", ErrorMessage = "MinPrice must be non-negative.")]
         public decimal? MinPrice { get; set; }
         [Range(typeof(decimal), "0", "99999999.99", ErrorMessage = "MaxPrice must be non-negative.")]

--- a/AIPharm.Backend/AIPharm.Core/Interfaces/ICategoryService.cs
+++ b/AIPharm.Backend/AIPharm.Core/Interfaces/ICategoryService.cs
@@ -1,3 +1,4 @@
+using System;
 using AIPharm.Core.DTOs;
 
 namespace AIPharm.Core.Interfaces
@@ -5,9 +6,9 @@ namespace AIPharm.Core.Interfaces
     public interface ICategoryService
     {
         Task<IEnumerable<CategoryDto>> GetCategoriesAsync();
-        Task<CategoryDto?> GetCategoryByIdAsync(int id);
+        Task<CategoryDto?> GetCategoryByIdAsync(Guid id);
         Task<CategoryDto> CreateCategoryAsync(CreateCategoryDto createCategoryDto);
-        Task<CategoryDto> UpdateCategoryAsync(int id, UpdateCategoryDto updateCategoryDto);
-        Task DeleteCategoryAsync(int id);
+        Task<CategoryDto> UpdateCategoryAsync(Guid id, UpdateCategoryDto updateCategoryDto);
+        Task DeleteCategoryAsync(Guid id);
     }
 }

--- a/AIPharm.Backend/AIPharm.Core/Interfaces/IRepository.cs
+++ b/AIPharm.Backend/AIPharm.Core/Interfaces/IRepository.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -6,6 +7,7 @@ namespace AIPharm.Core.Interfaces
     public interface IRepository<T> where T : class
     {
         Task<T?> GetByIdAsync(int id);
+        Task<T?> GetByIdAsync(Guid id);
         Task<T?> GetByIdAsync(string id);
         Task<IEnumerable<T>> GetAllAsync();
         Task<IEnumerable<T>> FindAsync(Expression<Func<T, bool>> predicate);
@@ -15,6 +17,7 @@ namespace AIPharm.Core.Interfaces
         Task<T> UpdateAsync(T entity);
         Task DeleteAsync(T entity);
         Task DeleteAsync(int id);
+        Task DeleteAsync(Guid id);
         Task DeleteAsync(string id);
         Task<int> CountAsync();
         Task<int> CountAsync(Expression<Func<T, bool>> predicate);

--- a/AIPharm.Backend/AIPharm.Core/Services/CategoryService.cs
+++ b/AIPharm.Backend/AIPharm.Core/Services/CategoryService.cs
@@ -1,3 +1,4 @@
+using System;
 using AutoMapper;
 using AIPharm.Core.DTOs;
 using AIPharm.Core.Interfaces;
@@ -35,7 +36,7 @@ namespace AIPharm.Core.Services
             return categoryDtos;
         }
 
-        public async Task<CategoryDto?> GetCategoryByIdAsync(int id)
+        public async Task<CategoryDto?> GetCategoryByIdAsync(Guid id)
         {
             var category = await _categoryRepository.GetByIdAsync(id);
             if (category == null) return null;
@@ -59,7 +60,7 @@ namespace AIPharm.Core.Services
             return categoryDto;
         }
 
-        public async Task<CategoryDto> UpdateCategoryAsync(int id, UpdateCategoryDto updateCategoryDto)
+        public async Task<CategoryDto> UpdateCategoryAsync(Guid id, UpdateCategoryDto updateCategoryDto)
         {
             var category = await _categoryRepository.GetByIdAsync(id);
             if (category == null)
@@ -75,7 +76,7 @@ namespace AIPharm.Core.Services
             return categoryDto;
         }
 
-        public async Task DeleteCategoryAsync(int id)
+        public async Task DeleteCategoryAsync(Guid id)
         {
             var category = await _categoryRepository.GetByIdAsync(id);
             if (category == null)

--- a/AIPharm.Backend/AIPharm.Core/Services/ProductService.cs
+++ b/AIPharm.Backend/AIPharm.Core/Services/ProductService.cs
@@ -1,3 +1,4 @@
+using System;
 using AutoMapper;
 using AIPharm.Core.DTOs;
 using AIPharm.Core.Interfaces;
@@ -27,7 +28,7 @@ namespace AIPharm.Core.Services
             var products = _productRepository.Query();
 
             // Apply filters
-            if (filter.CategoryId.HasValue)
+            if (filter.CategoryId.HasValue && filter.CategoryId.Value != Guid.Empty)
             {
                 products = products.Where(p => p.CategoryId == filter.CategoryId.Value);
             }
@@ -114,6 +115,11 @@ namespace AIPharm.Core.Services
 
         public async Task<ProductDto> CreateProductAsync(CreateProductDto createProductDto)
         {
+            if (createProductDto.CategoryId == Guid.Empty)
+            {
+                throw new ArgumentException("CategoryId must be a non-empty GUID.", nameof(CreateProductDto.CategoryId));
+            }
+
             var category = await _categoryRepository.GetByIdAsync(createProductDto.CategoryId);
             if (category == null)
             {
@@ -138,6 +144,11 @@ namespace AIPharm.Core.Services
 
             if (updateProductDto.CategoryId.HasValue)
             {
+                if (updateProductDto.CategoryId.Value == Guid.Empty)
+                {
+                    throw new ArgumentException("CategoryId must be a non-empty GUID.", nameof(UpdateProductDto.CategoryId));
+                }
+
                 var category = await _categoryRepository.GetByIdAsync(updateProductDto.CategoryId.Value);
                 if (category == null)
                 {
@@ -180,9 +191,9 @@ namespace AIPharm.Core.Services
                 throw new ArgumentOutOfRangeException(nameof(CreateProductDto.StockQuantity), "Stock quantity cannot be negative.");
             }
 
-            if (createProductDto.CategoryId <= 0)
+            if (createProductDto.CategoryId == Guid.Empty)
             {
-                throw new ArgumentOutOfRangeException(nameof(CreateProductDto.CategoryId), "CategoryId must be greater than zero.");
+                throw new ArgumentException("CategoryId must be a non-empty GUID.", nameof(CreateProductDto.CategoryId));
             }
         }
 
@@ -203,9 +214,9 @@ namespace AIPharm.Core.Services
                 throw new ArgumentOutOfRangeException(nameof(UpdateProductDto.StockQuantity), "Stock quantity cannot be negative.");
             }
 
-            if (updateProductDto.CategoryId.HasValue && updateProductDto.CategoryId.Value <= 0)
+            if (updateProductDto.CategoryId.HasValue && updateProductDto.CategoryId.Value == Guid.Empty)
             {
-                throw new ArgumentOutOfRangeException(nameof(UpdateProductDto.CategoryId), "CategoryId must be greater than zero.");
+                throw new ArgumentException("CategoryId must be a non-empty GUID.", nameof(UpdateProductDto.CategoryId));
             }
         }
     }

--- a/AIPharm.Backend/AIPharm.Domain/Entities/Category.cs
+++ b/AIPharm.Backend/AIPharm.Domain/Entities/Category.cs
@@ -1,10 +1,11 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace AIPharm.Domain.Entities
 {
     public class Category
     {
-        public int Id { get; set; }
+        public Guid Id { get; set; } = Guid.NewGuid();
         
         [Required]
         [MaxLength(100)]

--- a/AIPharm.Backend/AIPharm.Domain/Entities/Product.cs
+++ b/AIPharm.Backend/AIPharm.Domain/Entities/Product.cs
@@ -32,7 +32,7 @@ namespace AIPharm.Domain.Entities
         [MaxLength(500)]
         public string? ImageUrl { get; set; }
         
-        public int CategoryId { get; set; }
+        public Guid CategoryId { get; set; }
         
         public bool RequiresPrescription { get; set; } = false;
         

--- a/AIPharm.Backend/AIPharm.Infrastructure/Data/AIPharmDbContext.cs
+++ b/AIPharm.Backend/AIPharm.Infrastructure/Data/AIPharmDbContext.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using AIPharm.Domain.Entities;
 
@@ -51,8 +52,13 @@ namespace AIPharm.Infrastructure.Data
                         entity.ToTable("Categories", "dbo");
                         entity.HasKey(e => e.Id);
 
-                        entity.Property(e => e.Id)
+                        var categoryIdProperty = entity.Property(e => e.Id)
                         .ValueGeneratedOnAdd();
+
+                        if (Database.ProviderName?.Contains("SqlServer", StringComparison.OrdinalIgnoreCase) == true)
+                        {
+                              categoryIdProperty.HasDefaultValueSql("NEWID()");
+                        }
 
                         entity.Property(e => e.Name)
                         .IsRequired()

--- a/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20250920065040_InitialCreate.Designer.cs
+++ b/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20250920065040_InitialCreate.Designer.cs
@@ -63,7 +63,10 @@ namespace AIPharm.Infrastructure.Data.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier")
+                        .HasDefaultValueSql("NEWID()");
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");
@@ -233,8 +236,8 @@ namespace AIPharm.Infrastructure.Data.Migrations
                         .HasMaxLength(200)
                         .HasColumnType("nvarchar(200)");
 
-                    b.Property<int>("CategoryId")
-                        .HasColumnType("int");
+                    b.Property<Guid>("CategoryId")
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");

--- a/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20250920065040_InitialCreate.cs
+++ b/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20250920065040_InitialCreate.cs
@@ -19,8 +19,7 @@ namespace AIPharm.Infrastructure.Data.Migrations
                 schema: "dbo",
                 columns: table => new
                 {
-                    Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false, defaultValueSql: "NEWID()"),
                     Name = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
                     Description = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
                     Icon = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
@@ -67,7 +66,7 @@ namespace AIPharm.Infrastructure.Data.Migrations
                     Price = table.Column<decimal>(type: "decimal(10,2)", nullable: false),
                     StockQuantity = table.Column<int>(type: "int", nullable: false),
                     ImageUrl = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
-                    CategoryId = table.Column<int>(type: "int", nullable: false),
+                    CategoryId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     RequiresPrescription = table.Column<bool>(type: "bit", nullable: false),
                     ActiveIngredient = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
                     ActiveIngredientEn = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),

--- a/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20250923081808_AddEmailTwoFactor.Designer.cs
+++ b/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20250923081808_AddEmailTwoFactor.Designer.cs
@@ -63,7 +63,10 @@ namespace AIPharm.Infrastructure.Data.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier")
+                        .HasDefaultValueSql("NEWID()");
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");
@@ -94,11 +97,10 @@ namespace AIPharm.Infrastructure.Data.Migrations
 
             modelBuilder.Entity("AIPharm.Domain.Entities.Category", b =>
                 {
-                    b.Property<int>("Id")
+                    b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("uniqueidentifier")
+                        .HasDefaultValueSql("NEWID()");
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");
@@ -256,8 +258,8 @@ namespace AIPharm.Infrastructure.Data.Migrations
                         .HasMaxLength(200)
                         .HasColumnType("nvarchar(200)");
 
-                    b.Property<int>("CategoryId")
-                        .HasColumnType("int");
+                    b.Property<Guid>("CategoryId")
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");

--- a/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20250924090000_AddUserStaffFlag.Designer.cs
+++ b/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20250924090000_AddUserStaffFlag.Designer.cs
@@ -59,11 +59,10 @@ namespace AIPharm.Infrastructure.Data.Migrations
 
             modelBuilder.Entity("AIPharm.Domain.Entities.CartItem", b =>
                 {
-                    b.Property<int>("Id")
+                    b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("uniqueidentifier")
+                        .HasDefaultValueSql("NEWID()");
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");
@@ -94,11 +93,10 @@ namespace AIPharm.Infrastructure.Data.Migrations
 
             modelBuilder.Entity("AIPharm.Domain.Entities.Category", b =>
                 {
-                    b.Property<int>("Id")
+                    b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("uniqueidentifier")
+                        .HasDefaultValueSql("NEWID()");
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");
@@ -256,8 +254,8 @@ namespace AIPharm.Infrastructure.Data.Migrations
                         .HasMaxLength(200)
                         .HasColumnType("nvarchar(200)");
 
-                    b.Property<int>("CategoryId")
-                        .HasColumnType("int");
+                    b.Property<Guid>("CategoryId")
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");

--- a/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20251001090000_AddNhifAndVatEnhancements.Designer.cs
+++ b/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20251001090000_AddNhifAndVatEnhancements.Designer.cs
@@ -101,11 +101,10 @@ namespace AIPharm.Infrastructure.Data.Migrations
 
             modelBuilder.Entity("AIPharm.Domain.Entities.Category", b =>
                 {
-                    b.Property<int>("Id")
+                    b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("uniqueidentifier")
+                        .HasDefaultValueSql("NEWID()");
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");
@@ -336,8 +335,8 @@ namespace AIPharm.Infrastructure.Data.Migrations
                         .HasMaxLength(200)
                         .HasColumnType("nvarchar(200)");
 
-                    b.Property<int>("CategoryId")
-                        .HasColumnType("int");
+                    b.Property<Guid>("CategoryId")
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");

--- a/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/AIPharmDbContextModelSnapshot.cs
+++ b/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/AIPharmDbContextModelSnapshot.cs
@@ -24,11 +24,10 @@ namespace AIPharm.Infrastructure.Data.Migrations
 
             modelBuilder.Entity("AIPharm.Domain.Entities.AssistantMessage", b =>
                 {
-                    b.Property<int>("Id")
+                    b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("uniqueidentifier")
+                        .HasDefaultValueSql("NEWID()");
 
                     b.Property<string>("Content")
                         .IsRequired()
@@ -333,8 +332,8 @@ namespace AIPharm.Infrastructure.Data.Migrations
                         .HasMaxLength(200)
                         .HasColumnType("nvarchar(200)");
 
-                    b.Property<int>("CategoryId")
-                        .HasColumnType("int");
+                    b.Property<Guid>("CategoryId")
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");

--- a/AIPharm.Backend/AIPharm.Infrastructure/Repositories/Repository.cs
+++ b/AIPharm.Backend/AIPharm.Infrastructure/Repositories/Repository.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using System.Linq.Expressions;
 using AIPharm.Core.Interfaces;
@@ -22,6 +23,11 @@ namespace AIPharm.Infrastructure.Repositories
         }
 
         public virtual async Task<T?> GetByIdAsync(int id)
+        {
+            return await _dbSet.FindAsync(id);
+        }
+
+        public virtual async Task<T?> GetByIdAsync(Guid id)
         {
             return await _dbSet.FindAsync(id);
         }
@@ -67,6 +73,15 @@ namespace AIPharm.Infrastructure.Repositories
         }
 
         public virtual async Task DeleteAsync(int id)
+        {
+            var entity = await GetByIdAsync(id);
+            if (entity != null)
+            {
+                await DeleteAsync(entity);
+            }
+        }
+
+        public virtual async Task DeleteAsync(Guid id)
         {
             var entity = await GetByIdAsync(id);
             if (entity != null)

--- a/AIPharm.Backend/AIPharm.Web/Controllers/CategoriesController.cs
+++ b/AIPharm.Backend/AIPharm.Web/Controllers/CategoriesController.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.AspNetCore.Mvc;
 using AIPharm.Core.DTOs;
 using AIPharm.Core.Interfaces;
@@ -30,7 +31,7 @@ namespace AIPharm.Web.Controllers
         }
 
         [HttpGet("{id}")]
-        public async Task<ActionResult<CategoryDto>> GetCategory(int id)
+        public async Task<ActionResult<CategoryDto>> GetCategory(Guid id)
         {
             try
             {
@@ -62,7 +63,7 @@ namespace AIPharm.Web.Controllers
         }
 
         [HttpPut("{id}")]
-        public async Task<ActionResult<CategoryDto>> UpdateCategory(int id, [FromBody] UpdateCategoryDto updateCategoryDto)
+        public async Task<ActionResult<CategoryDto>> UpdateCategory(Guid id, [FromBody] UpdateCategoryDto updateCategoryDto)
         {
             try
             {
@@ -80,7 +81,7 @@ namespace AIPharm.Web.Controllers
         }
 
         [HttpDelete("{id}")]
-        public async Task<IActionResult> DeleteCategory(int id)
+        public async Task<IActionResult> DeleteCategory(Guid id)
         {
             try
             {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ function AppContent() {
   const { prescriptionFeaturesEnabled } = useFeatureToggles();
   const { products, categories } = useProductCatalog();
   const [searchTerm, setSearchTerm] = useState('');
-  const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -138,7 +138,7 @@ function AppContent() {
     }
   };
 
-  const handleCategoryChange = (categoryId: number | null) => {
+  const handleCategoryChange = (categoryId: string | null) => {
     setSelectedCategory(categoryId);
     setSearchTerm('');
     if (categoryId && location.pathname !== '/products') {

--- a/src/components/CategoryFilter.tsx
+++ b/src/components/CategoryFilter.tsx
@@ -6,8 +6,8 @@ import { useLanguage } from "../context/LanguageContext";
 import { getCategoryDisplayName, getCategoryIcon } from "../utils/categories";
 
 interface CategoryFilterProps {
-  selectedCategory: number | null;
-  onCategoryChange: (categoryId: number | null) => void;
+  selectedCategory: string | null;
+  onCategoryChange: (categoryId: string | null) => void;
   categories: Category[];
 }
 

--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -177,7 +177,7 @@ const mapProductToFormState = (product: Product): ProductFormState => ({
   price: product.price.toString(),
   stockQuantity: product.stockQuantity.toString(),
   imageUrl: product.imageUrl,
-  categoryId: product.categoryId.toString(),
+  categoryId: product.categoryId,
   requiresPrescription: product.requiresPrescription,
   activeIngredient: product.activeIngredient ?? '',
   activeIngredientEn: product.activeIngredientEn ?? product.activeIngredient ?? '',
@@ -938,7 +938,7 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
   }, [catalogProducts, productSearch]);
 
   const categoryById = useMemo(() => {
-    const map = new Map<number, string>();
+    const map = new Map<string, string>();
     catalogCategories.forEach((category) => {
       map.set(category.id, category.name);
     });
@@ -1416,7 +1416,7 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
     const dosageEn = productForm.dosageEn.trim();
     const manufacturer = productForm.manufacturer.trim();
     const manufacturerEn = productForm.manufacturerEn.trim();
-    const categoryId = Number(productForm.categoryId);
+    const categoryId = productForm.categoryId.trim();
     const price = Number(productForm.price);
     const stockQuantity = Number(productForm.stockQuantity);
 
@@ -1425,7 +1425,7 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
     if (!Number.isFinite(price) || price <= 0) errors.push(t('admin.products.errors.price'));
     if (!Number.isFinite(stockQuantity) || stockQuantity < 0)
       errors.push(t('admin.products.errors.stock'));
-    if (!Number.isInteger(categoryId) || categoryId <= 0)
+    if (!categoryId || !categoryById.has(categoryId))
       errors.push(t('admin.products.errors.category'));
     if (!imageUrl) errors.push(t('admin.products.errors.imageUrl'));
 

--- a/src/components/pages/CategoriesPage.tsx
+++ b/src/components/pages/CategoriesPage.tsx
@@ -9,7 +9,7 @@ import { getCategoryDisplayName, getCategoryIcon } from '../../utils/categories'
 interface CategoriesPageProps {
   categories: Category[];
   products: Product[];
-  onCategorySelect: (categoryId: number | null) => void;
+  onCategorySelect: (categoryId: string | null) => void;
 }
 
 const CategoriesPage: React.FC<CategoriesPageProps> = ({ categories, products, onCategorySelect }) => {
@@ -26,7 +26,7 @@ const CategoriesPage: React.FC<CategoriesPageProps> = ({ categories, products, o
     [categories, language, products],
   );
 
-  const handleCategoryClick = (categoryId: number) => {
+  const handleCategoryClick = (categoryId: string) => {
     onCategorySelect(categoryId);
   };
 

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -10,8 +10,8 @@ import { getCategoryDisplayName, getCategoryIcon } from '../../utils/categories'
 
 interface HomePageProps {
   searchTerm: string;
-  selectedCategory: number | null;
-  onCategoryChange: (categoryId: number | null) => void;
+  selectedCategory: string | null;
+  onCategoryChange: (categoryId: string | null) => void;
   filteredProducts: Product[];
   categories: Category[];
   showHero: boolean;

--- a/src/components/pages/ProductsPage.tsx
+++ b/src/components/pages/ProductsPage.tsx
@@ -9,8 +9,8 @@ import { useFeatureToggles } from '../../context/FeatureToggleContext';
 
 interface ProductsPageProps {
   searchTerm: string;
-  selectedCategory: number | null;
-  onCategoryChange: (categoryId: number | null) => void;
+  selectedCategory: string | null;
+  onCategoryChange: (categoryId: string | null) => void;
   filteredProducts: Product[];
   categories: Category[];
   allProducts: Product[];

--- a/src/context/ProductCatalogContext.tsx
+++ b/src/context/ProductCatalogContext.tsx
@@ -10,7 +10,7 @@ interface ProductInput {
   price: number;
   stockQuantity: number;
   imageUrl: string;
-  categoryId: number;
+  categoryId: string;
   requiresPrescription: boolean;
   activeIngredient?: string;
   activeIngredientEn?: string;

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -1,38 +1,47 @@
 import { Category, Product } from '../types';
 
+export const CATEGORY_IDS = {
+  analgesics: '11111111-1111-1111-1111-111111111111',
+  vitamins: '22222222-2222-2222-2222-222222222222',
+  coldFlu: '33333333-3333-3333-3333-333333333333',
+  digestive: '44444444-4444-4444-4444-444444444444',
+  skincare: '55555555-5555-5555-5555-555555555555',
+  kids: '66666666-6666-6666-6666-666666666666',
+} as const;
+
 export const categories: Category[] = [
   {
-    id: 1,
+    id: CATEGORY_IDS.analgesics,
     name: 'Обезболяващи',
     description: 'Лекарства за облекчаване на болка и възпаление',
     icon: 'pill',
   },
   {
-    id: 2,
+    id: CATEGORY_IDS.vitamins,
     name: 'Витамини',
     description: 'Хранителни добавки и витамини',
     icon: 'heart',
   },
   {
-    id: 3,
+    id: CATEGORY_IDS.coldFlu,
     name: 'Простуда и грип',
     description: 'Лекарства за простуда, кашлица и грип',
     icon: 'thermometer',
   },
   {
-    id: 4,
+    id: CATEGORY_IDS.digestive,
     name: 'Стомашно-чревни',
     description: 'Лекарства за храносмилателни проблеми',
     icon: 'stomach',
   },
   {
-    id: 5,
+    id: CATEGORY_IDS.skincare,
     name: 'Кожа и коса',
     description: 'Козметика и дермато-козметични продукти',
     icon: 'droplet',
   },
   {
-    id: 6,
+    id: CATEGORY_IDS.kids,
     name: 'Детски продукти',
     description: 'Специализирани продукти за деца',
     icon: 'baby',
@@ -52,7 +61,7 @@ export const products: Product[] = [
     stockQuantity: 150,
     imageUrl:
       'https://images.pexels.com/photos/3683074/pexels-photo-3683074.jpeg?auto=compress&cs=tinysrgb&w=400',
-    categoryId: 1,
+    categoryId: CATEGORY_IDS.analgesics,
     requiresPrescription: false,
     activeIngredient: 'Парацетамол',
     activeIngredientEn: 'Paracetamol',
@@ -72,7 +81,7 @@ export const products: Product[] = [
     stockQuantity: 95,
     imageUrl:
       'https://images.pexels.com/photos/3683081/pexels-photo-3683081.jpeg?auto=compress&cs=tinysrgb&w=400',
-    categoryId: 1,
+    categoryId: CATEGORY_IDS.analgesics,
     requiresPrescription: false,
     activeIngredient: 'Ибупрофен',
     activeIngredientEn: 'Ibuprofen',
@@ -92,7 +101,7 @@ export const products: Product[] = [
     stockQuantity: 200,
     imageUrl:
       'https://images.pexels.com/photos/3683107/pexels-photo-3683107.jpeg?auto=compress&cs=tinysrgb&w=400',
-    categoryId: 2,
+    categoryId: CATEGORY_IDS.vitamins,
     requiresPrescription: false,
     activeIngredient: 'Аскорбинова киселина',
     activeIngredientEn: 'Ascorbic Acid',
@@ -123,7 +132,7 @@ export const products: Product[] = [
     stockQuantity: 75,
     imageUrl:
       'https://images.pexels.com/photos/3683083/pexels-photo-3683083.jpeg?auto=compress&cs=tinysrgb&w=400',
-    categoryId: 2,
+    categoryId: CATEGORY_IDS.vitamins,
     requiresPrescription: false,
     activeIngredient: 'Магнезий оксид, Пиридоксин',
     activeIngredientEn: 'Magnesium Oxide, Pyridoxine',
@@ -154,7 +163,7 @@ export const products: Product[] = [
     stockQuantity: 120,
     imageUrl:
       'https://images.pexels.com/photos/3683051/pexels-photo-3683051.jpeg?auto=compress&cs=tinysrgb&w=400',
-    categoryId: 3,
+    categoryId: CATEGORY_IDS.coldFlu,
     requiresPrescription: false,
     activeIngredient: 'Екстракт от мед и лимон',
     activeIngredientEn: 'Honey and Lemon Extract',
@@ -174,7 +183,7 @@ export const products: Product[] = [
     stockQuantity: 85,
     imageUrl:
       'https://images.pexels.com/photos/3683050/pexels-photo-3683050.jpeg?auto=compress&cs=tinysrgb&w=400',
-    categoryId: 3,
+    categoryId: CATEGORY_IDS.coldFlu,
     requiresPrescription: false,
     activeIngredient: 'Ксилометазолин',
     activeIngredientEn: 'Xylometazoline',
@@ -194,7 +203,7 @@ export const products: Product[] = [
     stockQuantity: 60,
     imageUrl:
       'https://images.pexels.com/photos/3683110/pexels-photo-3683110.jpeg?auto=compress&cs=tinysrgb&w=400',
-    categoryId: 4,
+    categoryId: CATEGORY_IDS.digestive,
     requiresPrescription: false,
     activeIngredient: 'Лактобацили и бифидобактерии',
     activeIngredientEn: 'Lactobacilli and Bifidobacteria',
@@ -214,7 +223,7 @@ export const products: Product[] = [
     stockQuantity: 110,
     imageUrl:
       'https://images.pexels.com/photos/3683048/pexels-photo-3683048.jpeg?auto=compress&cs=tinysrgb&w=400',
-    categoryId: 4,
+    categoryId: CATEGORY_IDS.digestive,
     requiresPrescription: false,
     activeIngredient: 'Алуминиев хидроксид',
     activeIngredientEn: 'Aluminum Hydroxide',
@@ -245,7 +254,7 @@ export const products: Product[] = [
     stockQuantity: 90,
     imageUrl:
       'https://images.pexels.com/photos/3683099/pexels-photo-3683099.jpeg?auto=compress&cs=tinysrgb&w=400',
-    categoryId: 5,
+    categoryId: CATEGORY_IDS.skincare,
     requiresPrescription: false,
     activeIngredient: 'Хиалуронова киселина',
     activeIngredientEn: 'Hyaluronic Acid',
@@ -265,7 +274,7 @@ export const products: Product[] = [
     stockQuantity: 100,
     imageUrl:
       'https://images.pexels.com/photos/3683077/pexels-photo-3683077.jpeg?auto=compress&cs=tinysrgb&w=400',
-    categoryId: 6,
+    categoryId: CATEGORY_IDS.kids,
     requiresPrescription: false,
     activeIngredient: 'Парацетамол',
     activeIngredientEn: 'Paracetamol',
@@ -281,11 +290,11 @@ export const getProductById = (id: number): Product | undefined => {
   return products.find((p) => p.id === id);
 };
 
-export const getProductsByCategory = (categoryId: number): Product[] => {
+export const getProductsByCategory = (categoryId: string): Product[] => {
   return products.filter((p) => p.categoryId === categoryId);
 };
 
-export const getCategoryById = (id: number): Category | undefined => {
+export const getCategoryById = (id: string): Category | undefined => {
   return categories.find((c) => c.id === id);
 };
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -10,7 +10,7 @@ export interface ApiProduct {
     price: number;
     stockQuantity: number;
     imageUrl?: string;
-    categoryId: number;
+    categoryId: string;
     categoryName?: string;
     requiresPrescription: boolean;
     activeIngredient?: string;
@@ -21,7 +21,7 @@ export interface ApiProduct {
 }
 
 export interface ApiCategory {
-    id: number;
+    id: string;
     name: string;
     description?: string;
     icon: string;
@@ -60,7 +60,7 @@ export interface ApiPagedResult<T> {
 }
 
 export interface ProductFilter {
-    categoryId?: number;
+    categoryId?: string;
     minPrice?: number;
     maxPrice?: number;
     searchTerm?: string;
@@ -154,7 +154,7 @@ class ApiClient {
     // ----- Products -----
     getProducts(filter: ProductFilter = {}) {
         const params = new URLSearchParams();
-        if (filter.categoryId != null) params.append("categoryId", String(filter.categoryId));
+        if (filter.categoryId) params.append("categoryId", filter.categoryId);
         if (filter.minPrice != null) params.append("minPrice", String(filter.minPrice));
         if (filter.maxPrice != null) params.append("maxPrice", String(filter.maxPrice));
         if (filter.searchTerm) params.append("searchTerm", filter.searchTerm);
@@ -181,7 +181,7 @@ class ApiClient {
         return this.request<ApiCategory[]>("/categories");
     }
 
-    getCategory(id: number) {
+    getCategory(id: string) {
         return this.request<ApiCategory>(`/categories/${id}`);
     }
 
@@ -233,7 +233,7 @@ export function getProducts(filter?: ProductFilter) { return apiClient.getProduc
 export function getProduct(id: number) { return apiClient.getProduct(id); }
 export function searchProducts(searchTerm: string) { return apiClient.searchProducts(searchTerm); }
 export function getCategories() { return apiClient.getCategories(); }
-export function getCategory(id: number) { return apiClient.getCategory(id); }
+export function getCategory(id: string) { return apiClient.getCategory(id); }
 export function getCart() { return apiClient.getCart(); }
 export function addToCart(productId: number, quantity = 1) { return apiClient.addToCart(productId, quantity); }
 export function updateCartItem(cartItemId: number, quantity: number) { return apiClient.updateCartItem(cartItemId, quantity); }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 export interface Category {
-  id: number;
+  id: string;
   name: string;
   description?: string;
   icon: string;
@@ -26,7 +26,7 @@ export interface Product {
   price: number;
   stockQuantity: number;
   imageUrl: string;
-  categoryId: number;
+  categoryId: string;
   category?: Category;
   requiresPrescription: boolean;
   activeIngredient?: string;
@@ -137,7 +137,7 @@ export interface User {
 }
 
 export interface ProductFilter {
-  categoryId?: number;
+  categoryId?: string;
   minPrice?: number;
   maxPrice?: number;
   searchTerm?: string;

--- a/src/utils/imageGenerator.ts
+++ b/src/utils/imageGenerator.ts
@@ -1,4 +1,5 @@
 import { Category } from '../types';
+import { CATEGORY_IDS } from '../data/mockData';
 
 type Gradient = [string, string];
 
@@ -79,35 +80,35 @@ const createSvgDataUri = (
 };
 
 const productCategoryMap: Record<
-  number,
+  string,
   { subtitle: string; gradient: Gradient; icon: string }
 > = {
-  1: {
+  [CATEGORY_IDS.analgesics]: {
     subtitle: 'Pain Relief Essentials',
     gradient: ['#0f766e', '#14b8a6'],
     icon: '💊',
   },
-  2: {
+  [CATEGORY_IDS.vitamins]: {
     subtitle: 'Daily Vitamins & Wellness',
     gradient: ['#7c3aed', '#a855f7'],
     icon: '🌿',
   },
-  3: {
+  [CATEGORY_IDS.coldFlu]: {
     subtitle: 'Cold & Flu Care',
     gradient: ['#2563eb', '#38bdf8'],
     icon: '🤧',
   },
-  4: {
+  [CATEGORY_IDS.digestive]: {
     subtitle: 'Digestive Support',
     gradient: ['#f97316', '#fbbf24'],
     icon: '🫗',
   },
-  5: {
+  [CATEGORY_IDS.skincare]: {
     subtitle: 'Skin & Hair Care',
     gradient: ['#be123c', '#f43f5e'],
     icon: '✨',
   },
-  6: {
+  [CATEGORY_IDS.kids]: {
     subtitle: 'Kids Health',
     gradient: ['#2563eb', '#a855f7'],
     icon: '🧸',
@@ -125,7 +126,7 @@ const newsCategoryPalette: Record<string, Gradient> = {
 
 const defaultNewsGradient: Gradient = ['#312e81', '#6366f1'];
 
-export const generateProductImage = (title: string, categoryId: number): string => {
+export const generateProductImage = (title: string, categoryId: string): string => {
   const config = productCategoryMap[categoryId] ?? {
     subtitle: 'Pharmacy Essentials',
     gradient: ['#0369a1', '#38bdf8'] as Gradient,


### PR DESCRIPTION
## Summary
- convert categories to use GUID primary keys throughout the domain, services, and controllers
- update Entity Framework configuration and migrations to generate NEWID() identifiers for categories and to store GUID foreign keys
- align frontend types, API helpers, and admin tooling with GUID-based category identifiers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5694771348331a000f9fa13f85fb2