### PR TITLE
Switch Orders to GUID primary keys

### DIFF
--- a/AIPharm.Backend/AIPharm.Core/DTOs/OrderDto.cs
+++ b/AIPharm.Backend/AIPharm.Core/DTOs/OrderDto.cs
@@ -7,7 +7,7 @@ namespace AIPharm.Core.DTOs
 {
     public class OrderDto
     {
-        public int Id { get; set; }
+        public Guid Id { get; set; }
         public string OrderNumber { get; set; } = string.Empty;
         public string OrderKey => OrderNumber;
         public OrderStatus Status { get; set; }

--- a/AIPharm.Backend/AIPharm.Core/Interfaces/IOrderService.cs
+++ b/AIPharm.Backend/AIPharm.Core/Interfaces/IOrderService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using AIPharm.Core.DTOs;
@@ -10,6 +11,6 @@ namespace AIPharm.Core.Interfaces
         Task<OrderDto> CreateOrderAsync(string userId, CreateOrderDto orderDto);
         Task<IEnumerable<OrderDto>> GetOrdersForUserAsync(string userId);
         Task<IEnumerable<OrderDto>> GetAllOrdersAsync();
-        Task<OrderDto> UpdateOrderStatusAsync(int orderId, OrderStatus status);
+        Task<OrderDto> UpdateOrderStatusAsync(Guid orderId, OrderStatus status);
     }
 }

--- a/AIPharm.Backend/AIPharm.Core/Interfaces/IRepository.cs
+++ b/AIPharm.Backend/AIPharm.Core/Interfaces/IRepository.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -6,6 +7,7 @@ namespace AIPharm.Core.Interfaces
     public interface IRepository<T> where T : class
     {
         Task<T?> GetByIdAsync(int id);
+        Task<T?> GetByIdAsync(Guid id);
         Task<T?> GetByIdAsync(string id);
         Task<IEnumerable<T>> GetAllAsync();
         Task<IEnumerable<T>> FindAsync(Expression<Func<T, bool>> predicate);
@@ -15,6 +17,7 @@ namespace AIPharm.Core.Interfaces
         Task<T> UpdateAsync(T entity);
         Task DeleteAsync(T entity);
         Task DeleteAsync(int id);
+        Task DeleteAsync(Guid id);
         Task DeleteAsync(string id);
         Task<int> CountAsync();
         Task<int> CountAsync(Expression<Func<T, bool>> predicate);

--- a/AIPharm.Backend/AIPharm.Core/Services/OrderService.cs
+++ b/AIPharm.Backend/AIPharm.Core/Services/OrderService.cs
@@ -194,9 +194,9 @@ namespace AIPharm.Core.Services
             return orders.Select(MapOrder).ToList();
         }
 
-        public async Task<OrderDto> UpdateOrderStatusAsync(int orderId, OrderStatus status)
+        public async Task<OrderDto> UpdateOrderStatusAsync(Guid orderId, OrderStatus status)
         {
-            if (orderId <= 0)
+            if (orderId == Guid.Empty)
             {
                 throw new ArgumentOutOfRangeException(nameof(orderId));
             }

--- a/AIPharm.Backend/AIPharm.Domain/Entities/NhifPrescription.cs
+++ b/AIPharm.Backend/AIPharm.Domain/Entities/NhifPrescription.cs
@@ -21,7 +21,7 @@ namespace AIPharm.Domain.Entities
         public DateTime PurchaseDate { get; set; }
 
         [Required]
-        public int OrderId { get; set; }
+        public Guid OrderId { get; set; }
 
         [Required]
         [MaxLength(100)]

--- a/AIPharm.Backend/AIPharm.Domain/Entities/Order.cs
+++ b/AIPharm.Backend/AIPharm.Domain/Entities/Order.cs
@@ -23,7 +23,7 @@ namespace AIPharm.Domain.Entities
 
     public class Order
     {
-        public int Id { get; set; }
+        public Guid Id { get; set; }
 
         [Required]
         [Column("OrderUser")]

--- a/AIPharm.Backend/AIPharm.Domain/Entities/OrderItem.cs
+++ b/AIPharm.Backend/AIPharm.Domain/Entities/OrderItem.cs
@@ -8,7 +8,7 @@ namespace AIPharm.Domain.Entities
     {
         public int Id { get; set; }
         
-        public int OrderId { get; set; }
+        public Guid OrderId { get; set; }
         public int ProductId { get; set; }
         public int Quantity { get; set; }
         

--- a/AIPharm.Backend/AIPharm.Infrastructure/Data/AIPharmDbContext.cs
+++ b/AIPharm.Backend/AIPharm.Infrastructure/Data/AIPharmDbContext.cs
@@ -52,7 +52,8 @@ namespace AIPharm.Infrastructure.Data
                         entity.HasKey(e => e.Id);
 
                         entity.Property(e => e.Id)
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasDefaultValueSql("NEWID()");
 
                         entity.Property(e => e.Name)
                         .IsRequired()
@@ -72,7 +73,8 @@ namespace AIPharm.Infrastructure.Data
                         entity.HasKey(e => e.Id);
 
                         entity.Property(e => e.Id)
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasDefaultValueSql("NEWID()");
 
                         entity.Property(e => e.Name)
                         .IsRequired()
@@ -140,7 +142,8 @@ namespace AIPharm.Infrastructure.Data
                         entity.HasKey(e => e.Id);
 
                         entity.Property(e => e.Id)
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasDefaultValueSql("NEWID()");
 
                         entity.Property(e => e.OrderNumber)
                         .IsRequired()

--- a/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20250920065040_InitialCreate.Designer.cs
+++ b/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20250920065040_InitialCreate.Designer.cs
@@ -130,11 +130,10 @@ namespace AIPharm.Infrastructure.Data.Migrations
 
             modelBuilder.Entity("AIPharm.Domain.Entities.Order", b =>
                 {
-                    b.Property<int>("Id")
+                    b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasDefaultValueSql("NEWID()")
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");
@@ -187,8 +186,8 @@ namespace AIPharm.Infrastructure.Data.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
-                    b.Property<int>("OrderId")
-                        .HasColumnType("int");
+                    b.Property<Guid>("OrderId")
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("ProductDescription")
                         .HasMaxLength(200)

--- a/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20250920065040_InitialCreate.cs
+++ b/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20250920065040_InitialCreate.cs
@@ -98,8 +98,7 @@ namespace AIPharm.Infrastructure.Data.Migrations
                 schema: "dbo",
                 columns: table => new
                 {
-                    Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false, defaultValueSql: "NEWID()"),
                     UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
                     OrderNumber = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
                     Status = table.Column<int>(type: "int", nullable: false),
@@ -177,7 +176,7 @@ namespace AIPharm.Infrastructure.Data.Migrations
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
-                    OrderId = table.Column<int>(type: "int", nullable: false),
+                    OrderId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     ProductId = table.Column<int>(type: "int", nullable: false),
                     Quantity = table.Column<int>(type: "int", nullable: false),
                     UnitPrice = table.Column<decimal>(type: "decimal(10,2)", nullable: false),

--- a/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20250923081808_AddEmailTwoFactor.Designer.cs
+++ b/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20250923081808_AddEmailTwoFactor.Designer.cs
@@ -130,11 +130,10 @@ namespace AIPharm.Infrastructure.Data.Migrations
 
             modelBuilder.Entity("AIPharm.Domain.Entities.Order", b =>
                 {
-                    b.Property<int>("Id")
+                    b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasDefaultValueSql("NEWID()")
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");
@@ -210,8 +209,8 @@ namespace AIPharm.Infrastructure.Data.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
-                    b.Property<int>("OrderId")
-                        .HasColumnType("int");
+                    b.Property<Guid>("OrderId")
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("ProductDescription")
                         .HasMaxLength(200)

--- a/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20250924090000_AddUserStaffFlag.Designer.cs
+++ b/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20250924090000_AddUserStaffFlag.Designer.cs
@@ -130,11 +130,10 @@ namespace AIPharm.Infrastructure.Data.Migrations
 
             modelBuilder.Entity("AIPharm.Domain.Entities.Order", b =>
                 {
-                    b.Property<int>("Id")
+                    b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasDefaultValueSql("NEWID()")
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");
@@ -210,8 +209,8 @@ namespace AIPharm.Infrastructure.Data.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
-                    b.Property<int>("OrderId")
-                        .HasColumnType("int");
+                    b.Property<Guid>("OrderId")
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("ProductDescription")
                         .HasMaxLength(200)

--- a/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20251001090000_AddNhifAndVatEnhancements.Designer.cs
+++ b/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20251001090000_AddNhifAndVatEnhancements.Designer.cs
@@ -137,11 +137,10 @@ namespace AIPharm.Infrastructure.Data.Migrations
 
             modelBuilder.Entity("AIPharm.Domain.Entities.Order", b =>
                 {
-                    b.Property<int>("Id")
+                    b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasDefaultValueSql("NEWID()")
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");
@@ -230,8 +229,8 @@ namespace AIPharm.Infrastructure.Data.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
-                    b.Property<int>("OrderId")
-                        .HasColumnType("int");
+                    b.Property<Guid>("OrderId")
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("ProductDescription")
                         .HasMaxLength(200)
@@ -274,8 +273,8 @@ namespace AIPharm.Infrastructure.Data.Migrations
                     b.Property<decimal>("NhifPaidAmount")
                         .HasColumnType("decimal(10,2)");
 
-                    b.Property<int>("OrderId")
-                        .HasColumnType("int");
+                    b.Property<Guid>("OrderId")
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("OrderNumber")
                         .IsRequired()

--- a/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20251001090000_AddNhifAndVatEnhancements.cs
+++ b/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/20251001090000_AddNhifAndVatEnhancements.cs
@@ -105,7 +105,7 @@ namespace AIPharm.Infrastructure.Data.Migrations
                     PersonalIdentificationNumber = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: false),
                     PrescribedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
                     PurchaseDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    OrderId = table.Column<int>(type: "int", nullable: false),
+                    OrderId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     OrderNumber = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
                     UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
                     PatientPaidAmount = table.Column<decimal>(type: "decimal(10,2)", nullable: false),

--- a/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/AIPharmDbContextModelSnapshot.cs
+++ b/AIPharm.Backend/AIPharm.Infrastructure/Data/Migrations/AIPharmDbContextModelSnapshot.cs
@@ -134,11 +134,10 @@ namespace AIPharm.Infrastructure.Data.Migrations
 
             modelBuilder.Entity("AIPharm.Domain.Entities.Order", b =>
                 {
-                    b.Property<int>("Id")
+                    b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasDefaultValueSql("NEWID()")
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("datetime2");
@@ -227,8 +226,8 @@ namespace AIPharm.Infrastructure.Data.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
-                    b.Property<int>("OrderId")
-                        .HasColumnType("int");
+                    b.Property<Guid>("OrderId")
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("ProductDescription")
                         .HasMaxLength(200)
@@ -271,8 +270,8 @@ namespace AIPharm.Infrastructure.Data.Migrations
                     b.Property<decimal>("NhifPaidAmount")
                         .HasColumnType("decimal(10,2)");
 
-                    b.Property<int>("OrderId")
-                        .HasColumnType("int");
+                    b.Property<Guid>("OrderId")
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("OrderNumber")
                         .IsRequired()

--- a/AIPharm.Backend/AIPharm.Infrastructure/Repositories/Repository.cs
+++ b/AIPharm.Backend/AIPharm.Infrastructure/Repositories/Repository.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using System.Linq.Expressions;
 using AIPharm.Core.Interfaces;
@@ -22,6 +23,11 @@ namespace AIPharm.Infrastructure.Repositories
         }
 
         public virtual async Task<T?> GetByIdAsync(int id)
+        {
+            return await _dbSet.FindAsync(id);
+        }
+
+        public virtual async Task<T?> GetByIdAsync(Guid id)
         {
             return await _dbSet.FindAsync(id);
         }
@@ -67,6 +73,15 @@ namespace AIPharm.Infrastructure.Repositories
         }
 
         public virtual async Task DeleteAsync(int id)
+        {
+            var entity = await GetByIdAsync(id);
+            if (entity != null)
+            {
+                await DeleteAsync(entity);
+            }
+        }
+
+        public virtual async Task DeleteAsync(Guid id)
         {
             var entity = await GetByIdAsync(id);
             if (entity != null)

--- a/AIPharm.Backend/AIPharm.Web/Controllers/OrdersController.cs
+++ b/AIPharm.Backend/AIPharm.Web/Controllers/OrdersController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
@@ -92,9 +93,9 @@ namespace AIPharm.Web.Controllers
             }
         }
 
-        [HttpPatch("{orderId:int}/status")]
+        [HttpPatch("{orderId:guid}/status")]
         [Authorize(Roles = "Admin,Staff")]
-        public async Task<IActionResult> UpdateOrderStatus(int orderId, [FromBody] UpdateOrderStatusDto request)
+        public async Task<IActionResult> UpdateOrderStatus(Guid orderId, [FromBody] UpdateOrderStatusDto request)
         {
             if (!ModelState.IsValid)
             {

--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -78,7 +78,7 @@ interface ManagedOrderItem {
 }
 
 interface ManagedOrder {
-  id: number;
+  id: string;
   orderNumber: string;
   status: OrderStatus | number;
   paymentMethod: PaymentMethod | number;
@@ -402,7 +402,7 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
   const [ordersLoading, setOrdersLoading] = useState(false);
   const [ordersError, setOrdersError] = useState<string | null>(null);
   const [ordersToast, setOrdersToast] = useState<ToastState>(null);
-  const [statusUpdates, setStatusUpdates] = useState<Record<number, OrderStatus | null>>({});
+  const [statusUpdates, setStatusUpdates] = useState<Record<string, OrderStatus | null>>({});
   const [newsForm, setNewsForm] = useState<NewsFormState>(() => buildInitialNewsForm());
   const [newsErrors, setNewsErrors] = useState<string[]>([]);
   const [newsToast, setNewsToast] = useState<ToastState>(null);
@@ -644,7 +644,7 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
   }, [activeView, canManageOrders, fetchOrders, isPanelOpen]);
 
   const handleUpdateOrderStatus = useCallback(
-    async (orderId: number, status: OrderStatus) => {
+    async (orderId: string, status: OrderStatus) => {
       const token =
         localStorage.getItem('authToken') || sessionStorage.getItem('authToken');
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -85,7 +85,7 @@ export interface NhifPrescriptionSummary {
 }
 
 export interface OrderSummary {
-  id: number;
+  id: string;
   orderNumber: string;
   orderKey?: string;
   status: OrderStatus | number;


### PR DESCRIPTION
## Summary
- Convert the Order aggregate and related services to use GUID primary keys, including repository support and API changes.
- Update EF Core configuration, migrations, and snapshots to generate GUID order IDs via `NEWID()` and align dependent entities.
- Adjust the frontend order management views to treat order identifiers as string GUIDs.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e56f7fbac083319301e086a28d6ca4